### PR TITLE
feat: add draggable dashboard widgets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "react": "^18.2.0",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.2.0",
+        "react-grid-layout": "^1.5.2",
         "react-hook-form": "^7.54.2",
         "react-quill": "^2.0.0",
         "react-resizable-panels": "^2.1.7",
@@ -7273,6 +7274,44 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-draggable": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.5.0.tgz",
+      "integrity": "sha512-VC+HBLEZ0XJxnOxVAZsdRi8rD04Iz3SiiKOoYzamjylUcju/hP9np/aZdLHf/7WOD268WMoNJMvYfB5yAK45cw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-grid-layout": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-1.5.2.tgz",
+      "integrity": "sha512-vT7xmQqszTT+sQw/LfisrEO4le1EPNnSEMVHy6sBZyzS3yGkMywdOd+5iEFFwQwt0NSaGkxuRmYwa1JsP6OJdw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "fast-equals": "^4.0.3",
+        "prop-types": "^15.8.1",
+        "react-draggable": "^4.4.6",
+        "react-resizable": "^3.0.5",
+        "resize-observer-polyfill": "^1.5.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-grid-layout/node_modules/fast-equals": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-4.0.3.tgz",
+      "integrity": "sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg==",
+      "license": "MIT"
+    },
     "node_modules/react-hook-form": {
       "version": "7.62.0",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.62.0.tgz",
@@ -7365,6 +7404,19 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-resizable": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-3.0.5.tgz",
+      "integrity": "sha512-vKpeHhI5OZvYn82kXOs1bC8aOXktGU5AmKAgaZS4F5JPburCtbmDPqE7Pzp+1kN4+Wb81LlF33VpGwWwtXem+w==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "15.x",
+        "react-draggable": "^4.0.3"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3"
       }
     },
     "node_modules/react-resizable-panels": {
@@ -7579,6 +7631,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.5",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "react": "^18.2.0",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.2.0",
+    "react-grid-layout": "^1.5.2",
     "react-hook-form": "^7.54.2",
     "react-quill": "^2.0.0",
     "react-resizable-panels": "^2.1.7",

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,0 +1,134 @@
+import React, { useState } from "react";
+import { Responsive, WidthProvider } from "react-grid-layout";
+import "react-grid-layout/css/styles.css";
+import "react-resizable/css/styles.css";
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, BarChart, Bar, ResponsiveContainer } from "recharts";
+import { Button } from "@/components/ui/button";
+import { Document } from "@/api/entities";
+
+const ResponsiveGridLayout = WidthProvider(Responsive);
+
+const defaultLayout = [
+  { i: "line", x: 0, y: 0, w: 6, h: 4, type: "line" },
+  { i: "bar", x: 6, y: 0, w: 6, h: 4, type: "bar" },
+  { i: "kpi", x: 0, y: 4, w: 3, h: 2, type: "kpi" },
+  { i: "table", x: 3, y: 4, w: 9, h: 2, type: "table" },
+];
+
+const sampleData = [
+  { name: "Jan", value: 400, value2: 240 },
+  { name: "Feb", value: 300, value2: 139 },
+  { name: "Mar", value: 200, value2: 980 },
+  { name: "Apr", value: 278, value2: 390 },
+  { name: "May", value: 189, value2: 480 },
+];
+
+export default function Dashboard() {
+  const [layout, setLayout] = useState(defaultLayout);
+
+  const handleLayoutChange = (currentLayout) => {
+    // Preserve widget type
+    const updated = currentLayout.map((item) => {
+      const existing = layout.find((l) => l.i === item.i);
+      return { ...item, type: existing ? existing.type : item.i };
+    });
+    setLayout(updated);
+  };
+
+  const handleSave = async () => {
+    try {
+      await Document.create({
+        title: "Dashboard",
+        type: "dashboard",
+        config: JSON.stringify(layout),
+      });
+    } catch (error) {
+      console.error("Error saving dashboard:", error);
+    }
+  };
+
+  const renderWidget = (id) => {
+    switch (id) {
+      case "line":
+        return (
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={sampleData}>
+              <CartesianGrid stroke="#ccc" />
+              <XAxis dataKey="name" />
+              <YAxis />
+              <Tooltip />
+              <Line type="monotone" dataKey="value" stroke="#ff6b35" />
+            </LineChart>
+          </ResponsiveContainer>
+        );
+      case "bar":
+        return (
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={sampleData}>
+              <CartesianGrid stroke="#ccc" />
+              <XAxis dataKey="name" />
+              <YAxis />
+              <Tooltip />
+              <Bar dataKey="value2" fill="#ff6b35" />
+            </BarChart>
+          </ResponsiveContainer>
+        );
+      case "kpi":
+        return (
+          <div className="flex items-center justify-center h-full">
+            <div className="text-center">
+              <div className="text-xl font-bold mb-2">KPI</div>
+              <div className="text-4xl font-bold">42</div>
+            </div>
+          </div>
+        );
+      case "table":
+        return (
+          <div className="overflow-auto h-full">
+            <table className="w-full text-sm">
+              <thead>
+                <tr>
+                  <th className="text-left p-1">Nom</th>
+                  <th className="text-left p-1">Valeur</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sampleData.map((row) => (
+                  <tr key={row.name} className="border-t border-[var(--border-color)]">
+                    <td className="p-1">{row.name}</td>
+                    <td className="p-1">{row.value}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <Button onClick={handleSave} className="tactical-button">Sauvegarder</Button>
+      <ResponsiveGridLayout
+        className="layout"
+        layouts={{ lg: layout }}
+        cols={{ lg: 12 }}
+        rowHeight={100}
+        onLayoutChange={handleLayoutChange}
+        draggableHandle=".widget-header"
+      >
+        {layout.map((item) => (
+          <div key={item.i} data-grid={item} className="tactical-card p-2 h-full">
+            <div className="widget-header font-bold mb-2 cursor-move">
+              {item.type.charAt(0).toUpperCase() + item.type.slice(1)}
+            </div>
+            {renderWidget(item.i)}
+          </div>
+        ))}
+      </ResponsiveGridLayout>
+    </div>
+  );
+}
+

--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -8,6 +8,7 @@ import {
   Search,
   Compass,
   LayoutGrid,
+  LayoutDashboard,
   User,
   ChevronLeft,
   Monitor as MonitorIcon,
@@ -24,6 +25,7 @@ const mainNavItems = [
     { title: 'FICHIERS', href: createPageUrl('Files'), icon: LayoutGrid },
     { title: 'TERMINAL', href: createPageUrl('Terminal'), icon: TrendingUp },
     { title: 'MONITOR', href: createPageUrl('Monitor'), icon: BarChart3 },
+    { title: 'DASHBOARD', href: createPageUrl('Dashboard'), icon: LayoutDashboard },
   ];
 
 const secondaryNavItems = [

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -22,6 +22,7 @@ import Files from "./Files";
 
 import Terminal from "./Terminal";
 import Monitor from "./Monitor";
+import Dashboard from "./Dashboard";
 
 import { BrowserRouter as Router, Route, Routes, useLocation } from 'react-router-dom';
 
@@ -49,6 +50,7 @@ const PAGES = {
     
     Terminal: Terminal,
     Monitor: Monitor,
+    Dashboard: Dashboard,
     
 }
 
@@ -99,6 +101,7 @@ function PagesContent() {
                 
                 <Route path="/Terminal" element={<Terminal />} />
                 <Route path="/Monitor" element={<Monitor />} />
+                <Route path="/Dashboard" element={<Dashboard />} />
                 
             </Routes>
         </Layout>


### PR DESCRIPTION
## Summary
- add react-grid-layout powered dashboard page with line, bar, KPI and table widgets
- persist dashboard layout via Document.create
- expose dashboard route and navigation entry

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing lint errors in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c0ec1ef083308a447f7ca3caeec0