### PR TITLE
feat(task): allow scheduling

### DIFF
--- a/src/api/entities.js
+++ b/src/api/entities.js
@@ -7,6 +7,31 @@ export const Analysis = base44.entities.Analysis;
 
 export const Task = base44.entities.Task;
 
+if (!Task.schedule) {
+  Task.schedule = async (id, data) => {
+    const { serverUrl, appId } = base44.getConfig();
+    const token = typeof window !== 'undefined' ? localStorage.getItem('base44_access_token') : null;
+
+    const response = await fetch(
+      `${serverUrl}/api/apps/${appId}/entities/Task/${id}/schedule`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {})
+        },
+        body: JSON.stringify(data)
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`Failed to schedule task: ${response.statusText}`);
+    }
+
+    return response.json();
+  };
+}
+
 export const Document = base44.entities.Document;
 
 export const BrokerConnection = base44.entities.BrokerConnection;

--- a/src/components/tasks/TaskForm.jsx
+++ b/src/components/tasks/TaskForm.jsx
@@ -13,6 +13,7 @@ export default function TaskForm({ onSubmit, onCancel, selectedTemplate }) {
     type: selectedTemplate?.type || "",
     category: selectedTemplate?.category || "",
     frequency: "daily",
+    trigger: "09:00",
     parameters: {
       email_notifications: true
     }
@@ -123,6 +124,20 @@ export default function TaskForm({ onSubmit, onCancel, selectedTemplate }) {
                   <SelectItem value="quarterly" className="text-white font-mono">Trimestriel</SelectItem>
                 </SelectContent>
               </Select>
+            </div>
+
+            {/* Heure d'exécution */}
+            <div>
+              <label className="block text-sm font-bold text-[#a0a0a0] mb-2 font-mono uppercase tracking-wider">
+                Heure d'exécution
+              </label>
+              <Input
+                type="time"
+                value={formData.trigger}
+                onChange={(e) => setFormData({ ...formData, trigger: e.target.value })}
+                className="bg-[#1a1a1a] border-[#3a3a3a] text-white font-mono"
+                required
+              />
             </div>
 
             {/* Actions */}

--- a/src/pages/Tasks.jsx
+++ b/src/pages/Tasks.jsx
@@ -69,10 +69,16 @@ export default function TasksPage() {
 
   const handleCreateTask = async (taskData) => {
     try {
-      await Task.create({ // Changed from base44.entities.Task.create()
-        ...taskData,
+      const { frequency, trigger, ...payload } = taskData;
+      const newTask = await Task.create({ // Changed from base44.entities.Task.create()
+        ...payload,
         next_execution: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
       });
+
+      if (newTask?.id) {
+        await Task.schedule(newTask.id, { frequency, trigger });
+      }
+
       setShowForm(false);
       setSelectedTemplate(null);
       await loadTasks();


### PR DESCRIPTION
## Summary
- add custom `Task.schedule` endpoint
- expose trigger field and scheduling in task form
- schedule tasks when created

## Testing
- `npm run lint` *(fails: 830 problems)*
- `npm run build`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a8c10f1ed08330b8dac4c9680aa311