### PR TITLE
feat: fetch global index data from yahoo finance

### DIFF
--- a/src/api/marketData.js
+++ b/src/api/marketData.js
@@ -1,0 +1,48 @@
+const indicesMeta = [
+  { id: 11, symbol: '^DJI', name: 'DOW JONES', region: 'Americas' },
+  { id: 12, symbol: '^GSPC', name: 'S&P 500', region: 'Americas' },
+  { id: 13, symbol: '^IXIC', name: 'NASDAQ', region: 'Americas' },
+  { id: 14, symbol: '^GSPTSE', name: 'S&P/TSX Comp', region: 'Americas' },
+  { id: 16, symbol: '^BVSP', name: 'IBOVESPA', region: 'Americas' },
+  { id: 21, symbol: '^STOXX50E', name: 'Euro Stoxx 50', region: 'EMEA' },
+  { id: 22, symbol: '^FTSE', name: 'FTSE 100', region: 'EMEA' },
+  { id: 23, symbol: '^FCHI', name: 'CAC 40', region: 'EMEA' },
+  { id: 24, symbol: '^GDAXI', name: 'DAX', region: 'EMEA' },
+  { id: 31, symbol: '^N225', name: 'NIKKEI 225', region: 'APAC' },
+  { id: 32, symbol: '^HSI', name: 'HANG SENG', region: 'APAC' },
+  { id: 33, symbol: '000001.SS', name: 'SHANGHAI', region: 'APAC' },
+  { id: 34, symbol: '^AXJO', name: 'S&P/ASX 200', region: 'APAC' }
+];
+
+export async function fetchGlobalIndices() {
+  const url = `https://query1.finance.yahoo.com/v7/finance/quote?symbols=${indicesMeta.map(i => i.symbol).join(',')}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error('Failed to fetch market data');
+  }
+  const json = await res.json();
+  const quotes = json.quoteResponse.result;
+  const grouped = { Americas: [], EMEA: [], APAC: [] };
+
+  indicesMeta.forEach(meta => {
+    const quote = quotes.find(q => q.symbol === meta.symbol);
+    if (quote) {
+      const netChg = quote.regularMarketChange ?? 0;
+      const pctChg = quote.regularMarketChangePercent ?? 0;
+      const ytd = quote.ytdReturn != null ? quote.ytdReturn * 100 : null;
+      const item = {
+        id: meta.id,
+        name: meta.name,
+        value: quote.regularMarketPrice?.toFixed(2) ?? '0.00',
+        netChg: `${netChg >= 0 ? '+' : ''}${netChg.toFixed(2)}`,
+        pctChg: `${pctChg >= 0 ? '+' : ''}${pctChg.toFixed(2)}%`,
+        ytd: ytd != null ? `${ytd >= 0 ? '+' : ''}${ytd.toFixed(2)}%` : 'N/A'
+      };
+      grouped[meta.region].push(item);
+    }
+  });
+
+  return grouped;
+}
+
+export default fetchGlobalIndices;

--- a/src/components/markets/GlobalIndices.jsx
+++ b/src/components/markets/GlobalIndices.jsx
@@ -1,30 +1,9 @@
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Sparkline from './Sparkline';
+import fetchGlobalIndices from '../../api/marketData';
 
 const generateSparklineData = () => Array.from({ length: 20 }, () => Math.random() * 100);
-
-const indices = {
-  Americas: [
-    { id: 11, name: "DOW JONES", value: "34517.73", netChg: "+183.55", pctChg: "+0.53%", ytd: "2.89%" },
-    { id: 12, name: "S&P 500", value: "4489.15", netChg: "+37.24", pctChg: "+0.84%", ytd: "16.12%" },
-    { id: 13, name: "NASDAQ", value: "15129.50", netChg: "+123.77", pctChg: "+0.82%", ytd: "31.54%" },
-    { id: 14, name: "S&P/TSX Comp", value: "20546.12", netChg: "-12.50", pctChg: "-0.06%", ytd: "5.98%" },
-    { id: 16, name: "IBOVESPA", value: "118754.00", netChg: "+1201.00", pctChg: "+1.02%", ytd: "8.21%" },
-  ],
-  EMEA: [
-    { id: 21, name: "Euro Stoxx 50", value: "4321.45", netChg: "+45.10", pctChg: "+1.05%", ytd: "13.92%" },
-    { id: 22, name: "FTSE 100", value: "7628.10", netChg: "+65.20", pctChg: "+0.86%", ytd: "2.45%" },
-    { id: 23, name: "CAC 40", value: "7315.07", netChg: "+88.44", pctChg: "+1.22%", ytd: "12.98%" },
-    { id: 24, name: "DAX", value: "16010.32", netChg: "+150.78", pctChg: "+0.95%", ytd: "15.01%" },
-  ],
-  APAC: [
-    { id: 31, name: "NIKKEI 225", value: "32254.56", netChg: "+289.35", pctChg: "+0.90%", ytd: "23.55%" },
-    { id: 32, name: "HANG SENG", value: "18484.03", netChg: "-157.62", pctChg: "-0.85%", ytd: "-6.58%" },
-    { id: 33, name: "SHANGHAI", value: "3176.18", netChg: "+1.55", pctChg: "+0.05%", ytd: "2.87%" },
-    { id: 34, name: "S&P/ASX 200", value: "7307.00", netChg: "+48.90", pctChg: "+0.67%", ytd: "3.71%" },
-  ]
-};
 
 const DataRow = ({ id, name, value, netChg, pctChg, ytd }) => {
   const isPositive = !netChg.startsWith('-');
@@ -45,6 +24,24 @@ const DataRow = ({ id, name, value, netChg, pctChg, ytd }) => {
 };
 
 const GlobalIndices = () => {
+  const [indices, setIndices] = useState({});
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchGlobalIndices();
+        setIndices(data);
+      } catch (err) {
+        console.error('Failed to load market data', err);
+      }
+    };
+    load();
+  }, []);
+
+  if (!Object.keys(indices).length) {
+    return <div className="text-center py-4 text-[#a0a0a0]">Loading...</div>;
+  }
+
   return (
     <table className="w-full text-sm font-mono border-collapse table-fixed">
       <thead className="sticky top-0 bg-[#1a1a1a] z-10">


### PR DESCRIPTION
## Summary
- add market data service to fetch global index quotes from Yahoo Finance
- load and display live global index data in GlobalIndices component

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: multiple lint errors)

------
https://chatgpt.com/codex/tasks/task_e_68a8c2790f608330b6cd429baa1cf904