### PR TITLE
feat: add fetch wrapper with timeout and fallback

### DIFF
--- a/src/api/dataProviders.js
+++ b/src/api/dataProviders.js
@@ -1,0 +1,58 @@
+const CACHE_PREFIX = 'dataProvider:';
+
+/**
+ * Fetch JSON data with timeout and localStorage fallback.
+ * @param {string} url - Resource to fetch.
+ * @param {Object} [options] - Options.
+ * @param {Object} [options.fetchOptions] - Options passed to fetch.
+ * @param {number} [options.timeout=5000] - Timeout in ms.
+ * @param {string} [options.cacheKey] - Key used to cache the response.
+ * @returns {Promise<{data?: any, error?: string, fallback?: boolean}>}
+ */
+export async function fetchWithFallback(url, { fetchOptions = {}, timeout = 5000, cacheKey } = {}) {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+  try {
+    const response = await fetch(url, { ...fetchOptions, signal: controller.signal });
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      throw new Error(response.statusText || `Request failed with status ${response.status}`);
+    }
+
+    const data = await response.json();
+
+    if (cacheKey) {
+      try {
+        localStorage.setItem(CACHE_PREFIX + cacheKey, JSON.stringify(data));
+      } catch {
+        // Ignore caching errors
+      }
+    }
+
+    return { data };
+  } catch (error) {
+    clearTimeout(timeoutId);
+
+    let cachedData;
+    if (cacheKey) {
+      try {
+        const cached = localStorage.getItem(CACHE_PREFIX + cacheKey);
+        if (cached) {
+          cachedData = JSON.parse(cached);
+        }
+      } catch {
+        // Ignore cache parsing errors
+      }
+    }
+
+    if (cachedData !== undefined) {
+      return { data: cachedData, error: error.message, fallback: true };
+    }
+
+    return { error: error.message };
+  }
+}
+
+export default { fetchWithFallback };

--- a/src/api/dataProviders.js
+++ b/src/api/dataProviders.js
@@ -2,28 +2,40 @@ const CACHE_PREFIX = 'dataProvider:';
 
 /**
  * Fetch JSON data with timeout and localStorage fallback.
+ * Wraps the native `fetch` in a try/catch block and returns structured
+ * error information when a request fails. Successful responses are cached
+ * in `localStorage` and served as a fallback on subsequent failures.
+ *
  * @param {string} url - Resource to fetch.
  * @param {Object} [options] - Options.
  * @param {Object} [options.fetchOptions] - Options passed to fetch.
  * @param {number} [options.timeout=5000] - Timeout in ms.
- * @param {string} [options.cacheKey] - Key used to cache the response.
- * @returns {Promise<{data?: any, error?: string, fallback?: boolean}>}
+ * @param {string} [options.cacheKey] - Key used to cache the response. Defaults to the URL.
+ * @returns {Promise<{data?: any, error?: {message: string}, fallback?: boolean}>}
  */
-export async function fetchWithFallback(url, { fetchOptions = {}, timeout = 5000, cacheKey } = {}) {
+export default async function fetchWithFallback(
+  url,
+  { fetchOptions = {}, timeout = 5000, cacheKey = url } = {},
+) {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeout);
 
   try {
-    const response = await fetch(url, { ...fetchOptions, signal: controller.signal });
+    const response = await fetch(url, {
+      ...fetchOptions,
+      signal: controller.signal,
+    });
     clearTimeout(timeoutId);
 
     if (!response.ok) {
-      throw new Error(response.statusText || `Request failed with status ${response.status}`);
+      throw new Error(
+        response.statusText || `Request failed with status ${response.status}`,
+      );
     }
 
     const data = await response.json();
 
-    if (cacheKey) {
+    if (typeof localStorage !== 'undefined') {
       try {
         localStorage.setItem(CACHE_PREFIX + cacheKey, JSON.stringify(data));
       } catch {
@@ -36,7 +48,7 @@ export async function fetchWithFallback(url, { fetchOptions = {}, timeout = 5000
     clearTimeout(timeoutId);
 
     let cachedData;
-    if (cacheKey) {
+    if (typeof localStorage !== 'undefined') {
       try {
         const cached = localStorage.getItem(CACHE_PREFIX + cacheKey);
         if (cached) {
@@ -47,12 +59,17 @@ export async function fetchWithFallback(url, { fetchOptions = {}, timeout = 5000
       }
     }
 
+    const errMessage =
+      error && typeof error === 'object' && 'name' in error && error.name === 'AbortError'
+        ? 'Request timed out'
+        : error instanceof Error
+          ? error.message
+          : String(error);
+
     if (cachedData !== undefined) {
-      return { data: cachedData, error: error.message, fallback: true };
+      return { data: cachedData, error: { message: errMessage }, fallback: true };
     }
 
-    return { error: error.message };
+    return { error: { message: errMessage } };
   }
 }
-
-export default { fetchWithFallback };


### PR DESCRIPTION
## Summary
- add `fetchWithFallback` utility that wraps `fetch` calls
- include timeout, localStorage caching, and cached-data fallback

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: 801 errors, 28 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c279935083308f5bfa5db9e09ccf