### PR TITLE
Fetch World Bank data for explorer panel

### DIFF
--- a/src/components/explorer/CountryDataPanel.jsx
+++ b/src/components/explorer/CountryDataPanel.jsx
@@ -1,17 +1,88 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { X, Users, TrendingUp, DollarSign } from 'lucide-react';
+import {
+    X,
+    Users,
+    TrendingUp,
+    DollarSign,
+    Newspaper,
+    LineChart as LineChartIcon
+} from 'lucide-react';
+import {
+    ResponsiveContainer,
+    LineChart as ReLineChart,
+    Line,
+    XAxis,
+    YAxis,
+    Tooltip
+} from 'recharts';
 
 const StatItem = ({ label, value }) => (
     <div className="flex justify-between items-center py-2 border-b border-white/10">
         <span className="text-[#a0a0a0] font-mono text-sm">{label}</span>
-        <span className="text-white font-mono font-semibold text-sm">{value}</span>
+        <span className="text-white font-mono font-semibold text-sm">{value ?? 'N/A'}</span>
     </div>
 );
 
+const formatNumber = (num) => {
+    if (num === null || num === undefined) return 'N/A';
+    return Number(num).toLocaleString();
+};
+
 export default function CountryDataPanel({ country, onClose }) {
+    const [indicators, setIndicators] = useState({});
+    const [news, setNews] = useState([]);
+    const [gdpSeries, setGdpSeries] = useState([]);
+
+    useEffect(() => {
+        if (!country) return;
+
+        const fetchData = async () => {
+            try {
+                const [popRes, gdpRes, growthRes, inflationRes, gdpHistoryRes] = await Promise.all([
+                    fetch(`https://api.worldbank.org/v2/country/${country.code}/indicator/SP.POP.TOTL?format=json&per_page=1`),
+                    fetch(`https://api.worldbank.org/v2/country/${country.code}/indicator/NY.GDP.MKTP.CD?format=json&per_page=1`),
+                    fetch(`https://api.worldbank.org/v2/country/${country.code}/indicator/NY.GDP.MKTP.KD.ZG?format=json&per_page=1`),
+                    fetch(`https://api.worldbank.org/v2/country/${country.code}/indicator/FP.CPI.TOTL.ZG?format=json&per_page=1`),
+                    fetch(`https://api.worldbank.org/v2/country/${country.code}/indicator/NY.GDP.MKTP.CD?format=json&per_page=10`)
+                ]);
+
+                const popData = await popRes.json();
+                const gdpData = await gdpRes.json();
+                const growthData = await growthRes.json();
+                const inflationData = await inflationRes.json();
+                const gdpHistoryData = await gdpHistoryRes.json();
+
+                setIndicators({
+                    population: popData[1]?.[0]?.value,
+                    gdp: gdpData[1]?.[0]?.value,
+                    gdp_growth: growthData[1]?.[0]?.value,
+                    inflation: inflationData[1]?.[0]?.value
+                });
+
+                const series = (gdpHistoryData[1] || [])
+                    .filter(item => item.value !== null)
+                    .map(item => ({ year: item.date, value: item.value }))
+                    .reverse();
+                setGdpSeries(series);
+            } catch (err) {
+                console.error('Failed to fetch indicators', err);
+            }
+
+            try {
+                const newsRes = await fetch(`https://newsapi.org/v2/top-headlines?country=${country.code.toLowerCase()}&pageSize=5&apiKey=${import.meta.env.VITE_NEWS_API_KEY}`);
+                const newsData = await newsRes.json();
+                setNews(newsData.articles || []);
+            } catch (err) {
+                console.error('Failed to fetch news', err);
+            }
+        };
+
+        fetchData();
+    }, [country]);
+
     if (!country) return null;
 
     return (
@@ -41,9 +112,7 @@ export default function CountryDataPanel({ country, onClose }) {
                             <Users className="w-5 h-5" />
                             SOCIO-DÉMOGRAPHIQUE
                         </h3>
-                        <StatItem label="Population" value={country.socio.population} />
-                        <StatItem label="Espérance de vie" value={country.socio.life_expectancy} />
-                        <StatItem label="Indice de Dév. Humain" value={country.socio.hdi} />
+                        <StatItem label="Population" value={formatNumber(indicators.population)} />
                     </div>
 
                     {/* Économique */}
@@ -52,10 +121,8 @@ export default function CountryDataPanel({ country, onClose }) {
                             <TrendingUp className="w-5 h-5" />
                             ÉCONOMIQUE
                         </h3>
-                        <StatItem label="PIB (Nominal)" value={country.eco.gdp} />
-                        <StatItem label="Croissance PIB" value={country.eco.gdp_growth} />
-                        <StatItem label="Taux de chômage" value={country.eco.unemployment} />
-                        <StatItem label="Secteurs principaux" value={country.eco.main_sectors} />
+                        <StatItem label="PIB (USD)" value={formatNumber(indicators.gdp)} />
+                        <StatItem label="Croissance PIB (%)" value={indicators.gdp_growth != null ? indicators.gdp_growth.toFixed(2) : null} />
                     </div>
 
                     {/* Financier */}
@@ -64,9 +131,55 @@ export default function CountryDataPanel({ country, onClose }) {
                             <DollarSign className="w-5 h-5" />
                             FINANCIER
                         </h3>
-                        <StatItem label="Taux d'inflation" value={country.finance.inflation} />
-                        <StatItem label="Taux directeur" value={country.finance.interest_rate} />
-                        <StatItem label="Dette publique" value={country.finance.public_debt} />
+                        <StatItem label="Inflation (%)" value={indicators.inflation != null ? indicators.inflation.toFixed(2) : null} />
+                    </div>
+
+                    {/* Actualités */}
+                    <div className="space-y-3">
+                        <h3 className="flex items-center gap-3 text-lg font-semibold text-[#ff6b35] font-mono tracking-widest">
+                            <Newspaper className="w-5 h-5" />
+                            ACTUALITÉS
+                        </h3>
+                        {news.length > 0 ? (
+                            <ul className="space-y-2">
+                                {news.map(article => (
+                                    <li key={article.url}>
+                                        <a
+                                            href={article.url}
+                                            target="_blank"
+                                            rel="noreferrer"
+                                            className="text-[#a0a0a0] underline hover:text-white"
+                                        >
+                                            {article.title}
+                                        </a>
+                                    </li>
+                                ))}
+                            </ul>
+                        ) : (
+                            <p className="text-[#a0a0a0] font-mono text-sm">Aucune actualité disponible.</p>
+                        )}
+                    </div>
+
+                    {/* Graphique */}
+                    <div className="space-y-3">
+                        <h3 className="flex items-center gap-3 text-lg font-semibold text-[#ff6b35] font-mono tracking-widest">
+                            <LineChartIcon className="w-5 h-5" />
+                            PIB (10 DERNIÈRES ANNÉES)
+                        </h3>
+                        {gdpSeries.length > 0 ? (
+                            <div className="h-48">
+                                <ResponsiveContainer width="100%" height="100%">
+                                    <ReLineChart data={gdpSeries}>
+                                        <XAxis dataKey="year" stroke="#a0a0a0" />
+                                        <YAxis stroke="#a0a0a0" domain={[0, 'dataMax']} />
+                                        <Tooltip contentStyle={{ backgroundColor: '#171717', border: 'none' }} />
+                                        <Line type="monotone" dataKey="value" stroke="#ff6b35" strokeWidth={2} dot={false} />
+                                    </ReLineChart>
+                                </ResponsiveContainer>
+                            </div>
+                        ) : (
+                            <p className="text-[#a0a0a0] font-mono text-sm">Données de graphique indisponibles.</p>
+                        )}
                     </div>
                 </CardContent>
             </Card>

--- a/src/pages/Explorer.jsx
+++ b/src/pages/Explorer.jsx
@@ -4,82 +4,34 @@ import InteractiveWorldMap from '../components/explorer/InteractiveWorldMap';
 import CountryDataPanel from '../components/explorer/CountryDataPanel';
 import { AnimatePresence } from 'framer-motion';
 
-// Données mock pour les détails des pays (inchangées)
-const countryDetails = {
-    'France': {
-        name: 'France',
-        flag: '🇫🇷',
-        continent: 'Europe',
-        socio: {
-            population: '67.4M',
-            life_expectancy: '82.5 ans',
-            hdi: '0.903 (Très élevé)',
-        },
-        eco: {
-            gdp: '2.94T USD',
-            gdp_growth: '+0.9%',
-            unemployment: '7.3%',
-            main_sectors: 'Services, Industrie, Agriculture',
-        },
-        finance: {
-            inflation: '4.1%',
-            interest_rate: '4.50%',
-            public_debt: '112% du PIB',
-        }
-    },
-    'Germany': {
-        name: 'Allemagne',
-        flag: '🇩🇪',
-        continent: 'Europe',
-        socio: {
-            population: '83.2M',
-            life_expectancy: '81.0 ans',
-            hdi: '0.942 (Très élevé)',
-        },
-        eco: {
-            gdp: '4.26T USD',
-            gdp_growth: '+1.2%',
-            unemployment: '5.6%',
-            main_sectors: 'Automobile, Ingénierie, Chimie',
-        },
-        finance: {
-            inflation: '6.2%',
-            interest_rate: '4.50%',
-            public_debt: '68% du PIB',
-        }
-    },
-    'United States': {
-        name: 'États-Unis',
-        flag: '🇺🇸',
-        continent: 'Amérique du Nord',
-        socio: {
-            population: '331.9M',
-            life_expectancy: '77.3 ans',
-            hdi: '0.921 (Très élevé)',
-        },
-        eco: {
-            gdp: '23.32T USD',
-            gdp_growth: '+2.1%',
-            unemployment: '3.7%',
-            main_sectors: 'Technologie, Finance, Santé',
-        },
-        finance: {
-            inflation: '3.2%',
-            interest_rate: '5.50%',
-            public_debt: '129% du PIB',
-        }
-    },
-    // Ajouter plus de pays si nécessaire
-};
+// Convertit le code ISO2 en emoji drapeau
+const getFlagEmoji = (countryCode) =>
+    countryCode
+        .toUpperCase()
+        .replace(/./g, char => String.fromCodePoint(127397 + char.charCodeAt(0)));
 
 export default function ExplorerPage() {
     const [selectedCountry, setSelectedCountry] = useState(null);
 
-    const handleCountryClick = (countryName) => {
-        const matchedCountry = Object.keys(countryDetails).find(key => 
-            key.toLowerCase() === countryName.toLowerCase() || countryName.includes(key)
-        );
-        setSelectedCountry(countryDetails[matchedCountry] || null);
+    const handleCountryClick = async (countryName) => {
+        try {
+            const res = await fetch('https://api.worldbank.org/v2/country?format=json&per_page=400');
+            const data = await res.json();
+            const countries = data[1] || [];
+            const match = countries.find(c => c.name.toLowerCase() === countryName.toLowerCase());
+            if (match) {
+                setSelectedCountry({
+                    name: match.name,
+                    code: match.id,
+                    flag: getFlagEmoji(match.id)
+                });
+            } else {
+                setSelectedCountry(null);
+            }
+        } catch (error) {
+            console.error('Failed to fetch country data', error);
+            setSelectedCountry(null);
+        }
     };
 
     const handleClosePanel = () => {


### PR DESCRIPTION
## Summary
- Load country information from the World Bank API when clicking on the map
- Display dynamic indicators, news headlines, and GDP chart inside the country panel

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: React/Node lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c2cc175483309e9571c4f1933237