### PR TITLE
feat: add world bank and imf hooks

### DIFF
--- a/src/hooks/use-imf-series.jsx
+++ b/src/hooks/use-imf-series.jsx
@@ -1,0 +1,32 @@
+import * as React from "react"
+
+export function useIMFSeries(dataset, params = {}) {
+  const [data, setData] = React.useState(null)
+  const [error, setError] = React.useState(null)
+  const [loading, setLoading] = React.useState(false)
+
+  React.useEffect(() => {
+    if (!dataset) return
+    const controller = new AbortController()
+    const fetchData = async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        const search = new URLSearchParams(params).toString()
+        const url = `https://dataservices.imf.org/REST/SDMX_JSON.svc/CompactData/${dataset}?${search}`
+        const res = await fetch(url, { signal: controller.signal })
+        if (!res.ok) throw new Error("Network response was not ok")
+        const json = await res.json()
+        setData(json)
+      } catch (err) {
+        if (err.name !== "AbortError") setError(err)
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchData()
+    return () => controller.abort()
+  }, [dataset, JSON.stringify(params)])
+
+  return { data, error, loading }
+}

--- a/src/hooks/use-world-bank-indicator.jsx
+++ b/src/hooks/use-world-bank-indicator.jsx
@@ -1,0 +1,31 @@
+import * as React from "react"
+
+export function useWorldBankIndicator(country, code) {
+  const [data, setData] = React.useState(null)
+  const [error, setError] = React.useState(null)
+  const [loading, setLoading] = React.useState(false)
+
+  React.useEffect(() => {
+    if (!country || !code) return
+    const controller = new AbortController()
+    const fetchData = async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        const url = `https://api.worldbank.org/v2/country/${country}/indicator/${code}?format=json`
+        const res = await fetch(url, { signal: controller.signal })
+        if (!res.ok) throw new Error("Network response was not ok")
+        const json = await res.json()
+        setData(json[1] || [])
+      } catch (err) {
+        if (err.name !== "AbortError") setError(err)
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchData()
+    return () => controller.abort()
+  }, [country, code])
+
+  return { data, error, loading }
+}

--- a/src/pages/Economic.jsx
+++ b/src/pages/Economic.jsx
@@ -52,7 +52,15 @@ const NewsFeedCard = ({ item }) => (
     </CardContent>
     <CardFooter className="flex justify-between items-center">
       <div className="flex gap-2 flex-wrap">
-        {item.tags.map(tag => <Badge key={tag} variant="outline" className="border-[#2a2a2a] bg-[#0D0D0D] text-[#a3a3a3]">{tag}</Badge>)}
+        {item.tags.map(tag => (
+          <Badge
+            key={tag}
+            variant="outline"
+            className="border-[#2a2a2a] bg-[#0D0D0D] text-[#a3a3a3]"
+          >
+            {tag}
+          </Badge>
+        ))}
       </div>
       <div className="flex items-center gap-2 text-sm text-[#a3a3a3]">
         <Clock className="w-4 h-4" />

--- a/src/pages/Economic.jsx
+++ b/src/pages/Economic.jsx
@@ -10,6 +10,8 @@ import MonetaryPolicy from "../components/economic/MonetaryPolicy";
 import FiscalBudget from "../components/economic/FiscalBudget";
 import InternationalTrade from "../components/economic/InternationalTrade";
 import EconomicCalendar from "../components/economic/EconomicCalendar";
+import { useWorldBankIndicator } from "@/hooks/use-world-bank-indicator";
+import { useIMFSeries } from "@/hooks/use-imf-series";
 
 const categoryInfo = {
   title: "Analyse Économique",
@@ -62,6 +64,8 @@ const NewsFeedCard = ({ item }) => (
 
 export default function EconomicPage() {
   const [searchQuery, setSearchQuery] = useState("");
+  const { data: wbData, loading: wbLoading, error: wbError } = useWorldBankIndicator("FRA", "NY.GDP.MKTP.KD");
+  const { data: imfData, loading: imfLoading, error: imfError } = useIMFSeries("IFS/FRA.NGDP_RPCH.A", { startPeriod: "2020", endPeriod: "2024" });
 
   return (
     <div className="space-y-8 animate-fade-in">
@@ -101,6 +105,32 @@ export default function EconomicPage() {
       </Card>
       
       <EconomicCalendar />
+
+      <Card className="bg-[#171717] border-[#2a2a2a]">
+        <CardHeader>
+          <CardTitle className="text-lg text-[#e5e5e5]">Exemples d'API</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4 text-sm text-[#a3a3a3]">
+          <div>
+            <p className="font-medium mb-2">World Bank GDP (France)</p>
+            {wbLoading ? (
+              <p>Chargement...</p>
+            ) : (
+              <pre className="overflow-x-auto">{JSON.stringify(wbData?.[0], null, 2)}</pre>
+            )}
+            {wbError && <p className="text-red-500">{wbError.message}</p>}
+          </div>
+          <div>
+            <p className="font-medium mb-2">IMF GDP Growth (France)</p>
+            {imfLoading ? (
+              <p>Chargement...</p>
+            ) : (
+              <pre className="overflow-x-auto">{JSON.stringify(imfData?.CompactData?.DataSet?.Series?.[0], null, 2)}</pre>
+            )}
+            {imfError && <p className="text-red-500">{imfError.message}</p>}
+          </div>
+        </CardContent>
+      </Card>
 
       <div className="space-y-6">
         <h3 className="text-2xl font-semibold text-[#e5e5e5]">Fil d'actualité économique</h3>


### PR DESCRIPTION
## Summary
- add hook for querying World Bank indicator data
- add hook for retrieving IMF series
- show API usage examples on Economic page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 832 problems (802 errors, 30 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a8c27a604883308954ea0f987f1199