### PR TITLE
Add GDP, inflation and news explorer tools

### DIFF
--- a/src/components/explorer/tools/ToolGDP.jsx
+++ b/src/components/explorer/tools/ToolGDP.jsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from 'react';
+
+export default function ToolGDP({ country }) {
+  const [gdp, setGdp] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!country) return;
+    setLoading(true);
+    setError(null);
+
+    fetch(`https://api.worldbank.org/v2/country/${country}/indicator/NY.GDP.MKTP.CD?format=json&per_page=1`)
+      .then(res => res.json())
+      .then(data => {
+        const value = data?.[1]?.[0]?.value ?? null;
+        setGdp(value);
+      })
+      .catch(err => setError(err))
+      .finally(() => setLoading(false));
+  }, [country]);
+
+  if (!country) return null;
+
+  return (
+    <div className="text-[#a0a0a0] font-mono">
+      {loading && <p>Chargement du PIB...</p>}
+      {error && <p>Erreur lors du chargement du PIB.</p>}
+      {!loading && !error && (
+        <p>PIB: {gdp !== null ? gdp.toLocaleString() : 'N/A'}</p>
+      )}
+    </div>
+  );
+}

--- a/src/components/explorer/tools/ToolInflation.jsx
+++ b/src/components/explorer/tools/ToolInflation.jsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from 'react';
+
+export default function ToolInflation({ country }) {
+  const [inflation, setInflation] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!country) return;
+    setLoading(true);
+    setError(null);
+
+    fetch(`https://api.worldbank.org/v2/country/${country}/indicator/FP.CPI.TOTL.ZG?format=json&per_page=1`)
+      .then(res => res.json())
+      .then(data => {
+        const value = data?.[1]?.[0]?.value ?? null;
+        setInflation(value);
+      })
+      .catch(err => setError(err))
+      .finally(() => setLoading(false));
+  }, [country]);
+
+  if (!country) return null;
+
+  return (
+    <div className="text-[#a0a0a0] font-mono">
+      {loading && <p>Chargement de l'inflation...</p>}
+      {error && <p>Erreur lors du chargement de l'inflation.</p>}
+      {!loading && !error && (
+        <p>Inflation: {inflation !== null ? inflation.toFixed(2) + '%' : 'N/A'}</p>
+      )}
+    </div>
+  );
+}

--- a/src/components/explorer/tools/ToolNews.jsx
+++ b/src/components/explorer/tools/ToolNews.jsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from 'react';
+
+export default function ToolNews({ country }) {
+  const [articles, setArticles] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!country) return;
+    setLoading(true);
+    setError(null);
+
+    fetch(`https://hn.algolia.com/api/v1/search?query=${encodeURIComponent(country)}&tags=story&hitsPerPage=5`)
+      .then(res => res.json())
+      .then(data => setArticles(data?.hits || []))
+      .catch(err => setError(err))
+      .finally(() => setLoading(false));
+  }, [country]);
+
+  if (!country) return null;
+
+  return (
+    <div className="space-y-2 text-[#a0a0a0] font-mono">
+      {loading && <p>Chargement des actualités...</p>}
+      {error && <p>Erreur lors du chargement des actualités.</p>}
+      {!loading && !error && articles.map(article => (
+        <a
+          key={article.objectID}
+          href={article.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="block hover:underline text-sm"
+        >
+          {article.title}
+        </a>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add ToolGDP component querying World Bank GDP data by country
- add ToolInflation component querying World Bank inflation data
- add ToolNews widget pulling related headlines

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 837 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c2cc2bfc8330bdb5da4c41792d02