### PR TITLE
Add global chat panel with LLM integration

### DIFF
--- a/src/api/chat.js
+++ b/src/api/chat.js
@@ -1,0 +1,25 @@
+export async function sendChatMessage(messages, options = {}) {
+  const apiKey = import.meta.env.VITE_OPENAI_API_KEY;
+  const endpoint = import.meta.env.VITE_LLM_ENDPOINT || 'https://api.openai.com/v1/chat/completions';
+  const model = options.model || import.meta.env.VITE_LLM_MODEL || 'gpt-4o-mini';
+
+  const res = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+    },
+    body: JSON.stringify({
+      model,
+      messages,
+    }),
+  });
+
+  if (!res.ok) {
+    const errText = await res.text();
+    throw new Error(errText || 'LLM request failed');
+  }
+
+  const data = await res.json();
+  return data.choices?.[0]?.message?.content || '';
+}

--- a/src/components/common/ChatPanel.jsx
+++ b/src/components/common/ChatPanel.jsx
@@ -1,0 +1,98 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { MessageCircle, X, Send } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { sendChatMessage } from '@/api/chat';
+import { createPageUrl } from '@/utils';
+
+export default function ChatPanel() {
+  const [open, setOpen] = useState(false);
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
+
+  const handleCommand = (command) => {
+    switch (command) {
+      case '/monitor':
+        navigate(createPageUrl('Monitor'));
+        return true;
+      case '/task':
+        navigate(createPageUrl('Tasks'));
+        return true;
+      default:
+        return false;
+    }
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const text = input.trim();
+    if (!text) return;
+    setInput('');
+
+    if (text.startsWith('/')) {
+      if (handleCommand(text)) return;
+    }
+
+    const newMessages = [...messages, { role: 'user', content: text }];
+    setMessages(newMessages);
+    setLoading(true);
+    try {
+      const reply = await sendChatMessage(newMessages);
+      setMessages([...newMessages, { role: 'assistant', content: reply }]);
+    } catch (err) {
+      setMessages([...newMessages, { role: 'assistant', content: `Erreur: ${err.message}` }]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50">
+      {open ? (
+        <div className="mb-2 w-80 h-96 flex flex-col bg-[var(--sidebar-bg)]/95 backdrop-blur-sm border border-[var(--border-color)] rounded-lg shadow-lg">
+          <div className="flex items-center justify-between p-2 border-b border-[var(--border-color)]">
+            <span className="font-medium text-sm text-[var(--text-primary)]">Chat</span>
+            <button onClick={() => setOpen(false)} className="text-[var(--text-secondary)] hover:text-white">
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+          <div className="flex-1 overflow-y-auto p-2 space-y-2 text-sm">
+            {messages.map((m, idx) => (
+              <div key={idx} className={`flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+                <div
+                  className={`px-2 py-1 rounded max-w-[75%] ${
+                    m.role === 'user'
+                      ? 'bg-[var(--orange-primary)] text-white'
+                      : 'bg-[var(--hover-bg)] text-[var(--text-primary)]'
+                  }`}
+                >
+                  {m.content}
+                </div>
+              </div>
+            ))}
+            {loading && <div className="text-xs text-[var(--text-secondary)]">…</div>}
+          </div>
+          <form onSubmit={handleSubmit} className="p-2 border-t border-[var(--border-color)] flex items-center gap-2">
+            <Input
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              placeholder="Message"
+              className="flex-1 h-8 bg-transparent"
+              disabled={loading}
+            />
+            <Button type="submit" size="icon" className="h-8 w-8" disabled={loading || !input.trim()}>
+              <Send className="w-4 h-4" />
+            </Button>
+          </form>
+        </div>
+      ) : (
+        <Button size="icon" onClick={() => setOpen(true)} className="rounded-full">
+          <MessageCircle className="w-5 h-5" />
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -1,5 +1,4 @@
 
-import React from "react";
 import { Link, useLocation } from "react-router-dom";
 import { createPageUrl } from "@/utils";
 import {
@@ -17,6 +16,7 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import AnimatedBackground from "../components/common/AnimatedBackground";
+import ChatPanel from "@/components/common/ChatPanel.jsx";
 
 const mainNavItems = [
     { title: 'CHAT', href: createPageUrl('Intelligence'), icon: Search },
@@ -154,6 +154,7 @@ export default function Layout({ children }) {
             <main className="relative z-10 flex-1 overflow-y-auto bg-transparent p-4 sm:p-6 lg:p-8">
                  {children}
             </main>
+            <ChatPanel />
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- add chat API for LLM conversation history
- create floating ChatPanel with slash commands
- mount ChatPanel in Layout for universal access

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: 830 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c3e72500833099914ec20ddb2748