### PR TITLE
feat: add document context and chat uploads

### DIFF
--- a/src/api/chat.js
+++ b/src/api/chat.js
@@ -1,0 +1,29 @@
+import { Document } from "./entities";
+import { InvokeLLM } from "./integrations";
+
+/**
+ * Send a chat query to the LLM with additional context from stored documents.
+ * Performs a document search using Document.list to gather contextual data.
+ * @param {string} prompt - User question or prompt.
+ * @returns {Promise<any>} LLM response.
+ */
+export async function chat(prompt) {
+  let context = "";
+  try {
+    const docs = await Document.list({ search: prompt, limit: 5 });
+    if (Array.isArray(docs) && docs.length) {
+      context = docs
+        .map((d) => `${d.title || ""}${d.description ? " - " + d.description : ""}`)
+        .join("\n");
+    }
+  } catch (error) {
+    console.error("Error fetching context documents:", error);
+  }
+
+  try {
+    return await InvokeLLM({ prompt, context });
+  } catch (error) {
+    console.error("Error invoking LLM:", error);
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- implement chat API with Document.list context search
- enable drag and drop file uploads in chat sending to FilesPage
- wire chat UI to new API

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 801 errors, 28 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c3e807448330be8413916c6a64e9