### PR TITLE
feat: fetch live country data for explorer

### DIFF
--- a/src/components/explorer/CountryDataPanel.jsx
+++ b/src/components/explorer/CountryDataPanel.jsx
@@ -1,8 +1,10 @@
-import React from 'react';
 import { motion } from 'framer-motion';
+import PropTypes from 'prop-types';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { X, Users, TrendingUp, DollarSign } from 'lucide-react';
+import { X, Users, TrendingUp, DollarSign, Newspaper } from 'lucide-react';
+import { ChartContainer, ChartTooltip, ChartTooltipContent } from '@/components/ui/chart';
+import { Line, LineChart, XAxis, YAxis } from 'recharts';
 
 const StatItem = ({ label, value }) => (
     <div className="flex justify-between items-center py-2 border-b border-white/10">
@@ -11,8 +13,15 @@ const StatItem = ({ label, value }) => (
     </div>
 );
 
+StatItem.propTypes = {
+    label: PropTypes.string,
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+};
+
 export default function CountryDataPanel({ country, onClose }) {
     if (!country) return null;
+
+    const { indicators, news, gdpSeries } = country;
 
     return (
         <motion.div
@@ -25,7 +34,9 @@ export default function CountryDataPanel({ country, onClose }) {
             <Card className="tactical-card h-full flex flex-col bg-transparent border-none">
                 <CardHeader className="flex flex-row items-center justify-between p-4 border-b border-[#3a3a3a]">
                     <div className="flex items-center gap-4">
-                        <span className="text-4xl">{country.flag}</span>
+                        {country.flag && (
+                            <img src={country.flag} alt={country.name} className="w-10 h-6 object-cover" />
+                        )}
                         <CardTitle className="text-2xl font-bold text-white font-mono tracking-wider">
                             {country.name.toUpperCase()}
                         </CardTitle>
@@ -41,9 +52,7 @@ export default function CountryDataPanel({ country, onClose }) {
                             <Users className="w-5 h-5" />
                             SOCIO-DÉMOGRAPHIQUE
                         </h3>
-                        <StatItem label="Population" value={country.socio.population} />
-                        <StatItem label="Espérance de vie" value={country.socio.life_expectancy} />
-                        <StatItem label="Indice de Dév. Humain" value={country.socio.hdi} />
+                        <StatItem label="Population" value={indicators.population?.toLocaleString()} />
                     </div>
 
                     {/* Économique */}
@@ -52,10 +61,9 @@ export default function CountryDataPanel({ country, onClose }) {
                             <TrendingUp className="w-5 h-5" />
                             ÉCONOMIQUE
                         </h3>
-                        <StatItem label="PIB (Nominal)" value={country.eco.gdp} />
-                        <StatItem label="Croissance PIB" value={country.eco.gdp_growth} />
-                        <StatItem label="Taux de chômage" value={country.eco.unemployment} />
-                        <StatItem label="Secteurs principaux" value={country.eco.main_sectors} />
+                        <StatItem label="PIB (Nominal)" value={indicators.gdp?.toLocaleString()} />
+                        <StatItem label="Croissance PIB" value={indicators.gdp_growth} />
+                        <StatItem label="Taux de chômage" value={indicators.unemployment} />
                     </div>
 
                     {/* Financier */}
@@ -64,12 +72,78 @@ export default function CountryDataPanel({ country, onClose }) {
                             <DollarSign className="w-5 h-5" />
                             FINANCIER
                         </h3>
-                        <StatItem label="Taux d'inflation" value={country.finance.inflation} />
-                        <StatItem label="Taux directeur" value={country.finance.interest_rate} />
-                        <StatItem label="Dette publique" value={country.finance.public_debt} />
+                        <StatItem label="Taux d'inflation" value={indicators.inflation} />
+                        <StatItem label="Taux directeur" value={indicators.interest_rate} />
+                        <StatItem label="Dette publique (% PIB)" value={indicators.public_debt} />
                     </div>
+
+                    {/* Actualités */}
+                    {news?.length > 0 && (
+                        <div className="space-y-3">
+                            <h3 className="flex items-center gap-3 text-lg font-semibold text-[#ff6b35] font-mono tracking-widest">
+                                <Newspaper className="w-5 h-5" />
+                                ACTUALITÉS
+                            </h3>
+                            <ul className="space-y-2">
+                                {news.map(article => (
+                                    <li key={article.link} className="text-sm text-[#a0a0a0] font-mono">
+                                        <a href={article.link} target="_blank" rel="noopener noreferrer" className="hover:underline">
+                                            {article.title}
+                                        </a>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                    )}
+
+                    {/* Graphiques */}
+                    {gdpSeries?.length > 0 && (
+                        <div className="space-y-3">
+                            <h3 className="flex items-center gap-3 text-lg font-semibold text-[#ff6b35] font-mono tracking-widest">
+                                <TrendingUp className="w-5 h-5" />
+                                PIB - 10 DERNIÈRES ANNÉES
+                            </h3>
+                            <ChartContainer className="h-48" config={{ gdp: { color: '#ff6b35' } }}>
+                                <LineChart data={gdpSeries} margin={{ left: 12, right: 12 }}>
+                                    <XAxis dataKey="year" stroke="#a0a0a0" tickLine={false} axisLine={false} />
+                                    <YAxis stroke="#a0a0a0" tickLine={false} axisLine={false} tickFormatter={v => `${v/1e9}B`} />
+                                    <ChartTooltip content={<ChartTooltipContent />} />
+                                    <Line dataKey="value" type="monotone" stroke="var(--color-gdp)" strokeWidth={2} dot={false} />
+                                </LineChart>
+                            </ChartContainer>
+                        </div>
+                    )}
                 </CardContent>
             </Card>
         </motion.div>
     );
 }
+
+CountryDataPanel.propTypes = {
+    country: PropTypes.shape({
+        name: PropTypes.string.isRequired,
+        flag: PropTypes.string,
+        indicators: PropTypes.shape({
+            population: PropTypes.number,
+            gdp: PropTypes.number,
+            gdp_growth: PropTypes.number,
+            unemployment: PropTypes.number,
+            inflation: PropTypes.number,
+            interest_rate: PropTypes.number,
+            public_debt: PropTypes.number
+        }),
+        news: PropTypes.arrayOf(
+            PropTypes.shape({
+                title: PropTypes.string,
+                link: PropTypes.string
+            })
+        ),
+        gdpSeries: PropTypes.arrayOf(
+            PropTypes.shape({
+                year: PropTypes.string,
+                value: PropTypes.number
+            })
+        )
+    }),
+    onClose: PropTypes.func.isRequired
+};

--- a/src/pages/Explorer.jsx
+++ b/src/pages/Explorer.jsx
@@ -1,85 +1,85 @@
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import InteractiveWorldMap from '../components/explorer/InteractiveWorldMap';
 import CountryDataPanel from '../components/explorer/CountryDataPanel';
 import { AnimatePresence } from 'framer-motion';
 
-// Données mock pour les détails des pays (inchangées)
-const countryDetails = {
-    'France': {
-        name: 'France',
-        flag: '🇫🇷',
-        continent: 'Europe',
-        socio: {
-            population: '67.4M',
-            life_expectancy: '82.5 ans',
-            hdi: '0.903 (Très élevé)',
-        },
-        eco: {
-            gdp: '2.94T USD',
-            gdp_growth: '+0.9%',
-            unemployment: '7.3%',
-            main_sectors: 'Services, Industrie, Agriculture',
-        },
-        finance: {
-            inflation: '4.1%',
-            interest_rate: '4.50%',
-            public_debt: '112% du PIB',
-        }
-    },
-    'Germany': {
-        name: 'Allemagne',
-        flag: '🇩🇪',
-        continent: 'Europe',
-        socio: {
-            population: '83.2M',
-            life_expectancy: '81.0 ans',
-            hdi: '0.942 (Très élevé)',
-        },
-        eco: {
-            gdp: '4.26T USD',
-            gdp_growth: '+1.2%',
-            unemployment: '5.6%',
-            main_sectors: 'Automobile, Ingénierie, Chimie',
-        },
-        finance: {
-            inflation: '6.2%',
-            interest_rate: '4.50%',
-            public_debt: '68% du PIB',
-        }
-    },
-    'United States': {
-        name: 'États-Unis',
-        flag: '🇺🇸',
-        continent: 'Amérique du Nord',
-        socio: {
-            population: '331.9M',
-            life_expectancy: '77.3 ans',
-            hdi: '0.921 (Très élevé)',
-        },
-        eco: {
-            gdp: '23.32T USD',
-            gdp_growth: '+2.1%',
-            unemployment: '3.7%',
-            main_sectors: 'Technologie, Finance, Santé',
-        },
-        finance: {
-            inflation: '3.2%',
-            interest_rate: '5.50%',
-            public_debt: '129% du PIB',
-        }
-    },
-    // Ajouter plus de pays si nécessaire
-};
+// Helper to fetch a World Bank indicator for a country
+async function fetchIndicator(code, iso2) {
+    const res = await fetch(
+        `https://api.worldbank.org/v2/country/${iso2}/indicator/${code}?format=json&per_page=1`
+    );
+    const data = await res.json();
+    return data?.[1]?.[0]?.value || null;
+}
 
 export default function ExplorerPage() {
     const [selectedCountry, setSelectedCountry] = useState(null);
 
-    const handleCountryClick = (countryName) => {
-        const matchedCountry = Object.keys(countryDetails).find(key => 
-            key.toLowerCase() === countryName.toLowerCase() || countryName.includes(key)
-        );
-        setSelectedCountry(countryDetails[matchedCountry] || null);
+    const handleCountryClick = async (countryName) => {
+        try {
+            // Get ISO codes and flag from RestCountries
+            const infoRes = await fetch(
+                `https://restcountries.com/v3.1/name/${encodeURIComponent(countryName)}?fields=cca2,name,flags`
+            );
+            const infoData = await infoRes.json();
+            const countryInfo = infoData?.[0];
+            const iso2 = countryInfo?.cca2?.toLowerCase();
+
+            if (!iso2) return;
+
+            // Fetch indicators from World Bank
+            const [population, gdp, gdpGrowth, unemployment, inflation, interestRate, publicDebt] = await Promise.all([
+                fetchIndicator('SP.POP.TOTL', iso2),
+                fetchIndicator('NY.GDP.MKTP.CD', iso2),
+                fetchIndicator('NY.GDP.MKTP.KD.ZG', iso2),
+                fetchIndicator('SL.UEM.TOTL.ZS', iso2),
+                fetchIndicator('FP.CPI.TOTL.ZG', iso2),
+                fetchIndicator('FR.INR.RINR', iso2),
+                fetchIndicator('GC.DOD.TOTL.GD.ZS', iso2)
+            ]);
+
+            // GDP time series for chart
+            const seriesRes = await fetch(
+                `https://api.worldbank.org/v2/country/${iso2}/indicator/NY.GDP.MKTP.CD?format=json&per_page=10`
+            );
+            const seriesData = await seriesRes.json();
+            const gdpSeries = (seriesData?.[1] || []).map(item => ({
+                year: item.date,
+                value: item.value
+            })).reverse();
+
+            // News from external source (API key required)
+            let news = [];
+            try {
+                const newsRes = await fetch(
+                    `https://newsdata.io/api/1/news?apikey=${import.meta.env.VITE_NEWS_API_KEY}&country=${iso2}`
+                );
+                const newsJson = await newsRes.json();
+                news = newsJson?.results?.slice(0, 5) || [];
+            } catch (err) {
+                console.error('Failed to fetch news', err);
+            }
+
+            setSelectedCountry({
+                name: countryInfo?.name?.common || countryName,
+                flag: countryInfo?.flags?.svg || '',
+                indicators: {
+                    population,
+                    gdp,
+                    gdp_growth: gdpGrowth,
+                    unemployment,
+                    inflation,
+                    interest_rate: interestRate,
+                    public_debt: publicDebt
+                },
+                news,
+                gdpSeries
+            });
+        } catch (error) {
+            console.error('Country fetch failed', error);
+            setSelectedCountry(null);
+        }
     };
 
     const handleClosePanel = () => {
@@ -99,8 +99,8 @@ export default function ExplorerPage() {
                 <div className="flex-1 bg-[#2a2a2a] border border-[#3a3a3a] rounded-lg p-6">
                     <div className="flex items-center justify-center h-full">
                         <div className="text-center space-y-4">
-                            <h3 className="text-xl font-bold text-white font-mono tracking-wider">ZONE D'OUTILS OPÉRATIONNELS</h3>
-                            <p className="text-[#a0a0a0] font-mono">Espace réservé pour les outils d'analyse et contrôles tactiques.</p>
+                            <h3 className="text-xl font-bold text-white font-mono tracking-wider">ZONE D&apos;OUTILS OPÉRATIONNELS</h3>
+                            <p className="text-[#a0a0a0] font-mono">Espace réservé pour les outils d&apos;analyse et contrôles tactiques.</p>
                             <div className="grid grid-cols-3 gap-4 mt-8 max-w-md mx-auto">
                                 <div className="h-16 bg-[#3a3a3a] rounded border border-[#4a4a4a] flex items-center justify-center">
                                     <span className="text-xs text-[#a0a0a0] font-mono">OUTIL 1</span>


### PR DESCRIPTION
## Summary
- replace static country details with World Bank and news API calls
- show dynamic indicators, headlines, and GDP charts in CountryDataPanel

## Testing
- `npm run lint` *(fails: existing lint errors in unrelated files)*
- `npx eslint src/pages/Explorer.jsx src/components/explorer/CountryDataPanel.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68a8c3f0c08483308b4d16ae57a87b40