### PR TITLE
feat: add global search component

### DIFF
--- a/src/components/common/GlobalSearch.jsx
+++ b/src/components/common/GlobalSearch.jsx
@@ -1,0 +1,35 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Input } from "@/components/ui/input";
+import { createPageUrl } from "@/utils";
+
+export default function GlobalSearch() {
+  const [query, setQuery] = useState("");
+  const navigate = useNavigate();
+
+  const handleKeyDown = (e) => {
+    if (e.key === "Enter" && query.trim()) {
+      const q = query.trim();
+      if (q.startsWith("file:")) {
+        const path = q.slice(5).trim();
+        navigate(`${createPageUrl("Files")}?q=${encodeURIComponent(path)}`);
+      } else if (q.startsWith("$")) {
+        const ticker = q.slice(1).trim();
+        navigate(`${createPageUrl("Terminal")}?ticker=${encodeURIComponent(ticker)}`);
+      } else {
+        navigate(`${createPageUrl("Explorer")}?q=${encodeURIComponent(q)}`);
+      }
+      setQuery("");
+    }
+  };
+
+  return (
+    <Input
+      value={query}
+      onChange={(e) => setQuery(e.target.value)}
+      onKeyDown={handleKeyDown}
+      placeholder="Search... (file: path, $ticker)"
+      className="mb-4 bg-[var(--sidebar-bg)] border-[var(--border-color)] text-[var(--text-primary)] placeholder-[var(--text-secondary)]"
+    />
+  );
+}

--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -17,6 +17,7 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import AnimatedBackground from "../components/common/AnimatedBackground";
+import GlobalSearch from "../components/common/GlobalSearch";
 
 const mainNavItems = [
     { title: 'CHAT', href: createPageUrl('Intelligence'), icon: Search },
@@ -152,6 +153,7 @@ export default function Layout({ children }) {
 
             {/* Contenu Principal */}
             <main className="relative z-10 flex-1 overflow-y-auto bg-transparent p-4 sm:p-6 lg:p-8">
+                 <GlobalSearch />
                  {children}
             </main>
         </div>


### PR DESCRIPTION
## Summary
- add GlobalSearch component to route queries based on prefixes
- integrate GlobalSearch into layout

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 829 problems)


------
https://chatgpt.com/codex/tasks/task_e_68a8c3f796408330887ed298f52a2ab0