### PR TITLE
feat: add fetch timeout and cache fallback

### DIFF
--- a/src/api/dataProviders.js
+++ b/src/api/dataProviders.js
@@ -1,0 +1,45 @@
+const DEFAULT_TIMEOUT = 5000;
+
+// Helper function to perform fetch with timeout and fallback to cache
+export async function fetchWithTimeout(url, { timeout = DEFAULT_TIMEOUT, cacheKey, ...options } = {}) {
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), timeout);
+  try {
+    const response = await fetch(url, { ...options, signal: controller.signal });
+    clearTimeout(id);
+    if (!response.ok) {
+      throw new Error(`Request failed with status ${response.status}`);
+    }
+    const data = await response.json();
+    if (cacheKey) {
+      try {
+        localStorage.setItem(cacheKey, JSON.stringify(data));
+      } catch (_) {
+        // ignore storage errors
+      }
+    }
+    return { data };
+  } catch (error) {
+    clearTimeout(id);
+    let fallback;
+    if (cacheKey) {
+      try {
+        const cached = localStorage.getItem(cacheKey);
+        if (cached) {
+          fallback = JSON.parse(cached);
+        }
+      } catch (_) {
+        // ignore storage errors
+      }
+    }
+    return fallback ? { data: fallback, error } : { error };
+  }
+}
+
+// Example provider: fetch world countries GeoJSON
+export function getCountriesGeoJSON() {
+  return fetchWithTimeout(
+    'https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_110m_admin_0_countries.geojson',
+    { cacheKey: 'countriesGeoJSON' }
+  );
+}

--- a/src/components/explorer/InteractiveWorldMap.jsx
+++ b/src/components/explorer/InteractiveWorldMap.jsx
@@ -1,6 +1,7 @@
 
 import React, { useRef, useEffect, useState } from 'react';
 import * as THREE from 'three';
+import { getCountriesGeoJSON } from '../../api/dataProviders';
 
 const InteractiveWorldMap = ({ onCountryClick }) => {
   const mountRef = useRef(null);
@@ -130,13 +131,14 @@ const InteractiveWorldMap = ({ onCountryClick }) => {
         return shapes;
     }
 
-    fetch('https://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_110m_admin_0_countries.geojson')
-      .then(res => res.json())
-      .then(drawCountries)
-      .catch(err => {
-          console.error("Failed to load GeoJSON", err);
-          setLoading(false);
-      });
+    getCountriesGeoJSON().then(({ data, error }) => {
+      if (error) {
+        console.error("Failed to load GeoJSON", error);
+        setLoading(false);
+        return;
+      }
+      drawCountries(data);
+    });
 
     // Gestion du redimensionnement de la fenêtre
     function handleResize() {


### PR DESCRIPTION
## Summary
- add data provider with fetch timeout and local cache fallback
- use data provider in interactive world map

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 803 errors, 28 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68a8c3a95b248330b4df3fcecfe502b9