### PR TITLE
feat: add economic data hooks

### DIFF
--- a/src/hooks/use-imf-series.js
+++ b/src/hooks/use-imf-series.js
@@ -1,0 +1,38 @@
+import * as React from "react";
+
+export function useIMFSeries(dataset, params = {}) {
+  const { frequency = "A", country, series, startPeriod, endPeriod } = params;
+  const [data, setData] = React.useState(null);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState(null);
+
+  React.useEffect(() => {
+    if (!dataset || !country || !series) return;
+    const controller = new AbortController();
+    setLoading(true);
+    const path = `${frequency}.${country}.${series}`;
+    const searchParams = new URLSearchParams();
+    if (startPeriod) searchParams.set("startPeriod", startPeriod);
+    if (endPeriod) searchParams.set("endPeriod", endPeriod);
+    const baseUrl = "https://dataservices.imf.org/REST/SDMX_JSON.svc/CompactData";
+    const url = `${baseUrl}/${dataset}/${path}${searchParams.toString() ? `?${searchParams.toString()}` : ""}`;
+    fetch(url, { signal: controller.signal })
+      .then((res) => {
+        if (!res.ok) throw new Error("Network response was not ok");
+        return res.json();
+      })
+      .then((json) => {
+        const seriesData = json?.CompactData?.DataSet?.Series?.Obs || [];
+        setData(seriesData);
+        setLoading(false);
+      })
+      .catch((err) => {
+        if (err.name === "AbortError") return;
+        setError(err);
+        setLoading(false);
+      });
+    return () => controller.abort();
+  }, [dataset, country, series, frequency, startPeriod, endPeriod]);
+
+  return { data, loading, error };
+}

--- a/src/hooks/use-world-bank-indicator.js
+++ b/src/hooks/use-world-bank-indicator.js
@@ -1,0 +1,33 @@
+import * as React from "react";
+
+export function useWorldBankIndicator(country, code) {
+  const [data, setData] = React.useState(null);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState(null);
+
+  React.useEffect(() => {
+    if (!country || !code) return;
+    const controller = new AbortController();
+    setLoading(true);
+    fetch(`https://api.worldbank.org/v2/country/${country}/indicator/${code}?format=json`, {
+      signal: controller.signal
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error("Network response was not ok");
+        return res.json();
+      })
+      .then((json) => {
+        const series = Array.isArray(json) ? json[1] : [];
+        setData(series);
+        setLoading(false);
+      })
+      .catch((err) => {
+        if (err.name === "AbortError") return;
+        setError(err);
+        setLoading(false);
+      });
+    return () => controller.abort();
+  }, [country, code]);
+
+  return { data, loading, error };
+}

--- a/src/pages/Economic.jsx
+++ b/src/pages/Economic.jsx
@@ -1,5 +1,7 @@
 
 import React, { useState } from "react";
+import { useWorldBankIndicator } from "@/hooks/use-world-bank-indicator"
+import { useIMFSeries } from "@/hooks/use-imf-series"
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardFooter } from "@/components/ui/card";
@@ -63,6 +65,9 @@ const NewsFeedCard = ({ item }) => (
 export default function EconomicPage() {
   const [searchQuery, setSearchQuery] = useState("");
 
+  const { data: gdpData, loading: gdpLoading } = useWorldBankIndicator("USA", "NY.GDP.MKTP.CD");
+  const { data: imfData, loading: imfLoading } = useIMFSeries("IFS", { country: "US", series: "NGDP_RPCH", startPeriod: "2019", endPeriod: "2023" });
+
   return (
     <div className="space-y-8 animate-fade-in">
        <Card className="bg-[#171717] border-[#2a2a2a]">
@@ -101,6 +106,12 @@ export default function EconomicPage() {
       </Card>
       
       <EconomicCalendar />
+
+      <div className="space-y-4">
+        <h3 className="text-xl font-semibold text-[#e5e5e5]">Exemples d&#39;API</h3>
+        <pre className="text-xs text-[#a3a3a3] bg-[#0D0D0D] p-4 rounded overflow-x-auto">{gdpLoading ? "Chargement des données World Bank..." : JSON.stringify(gdpData?.[0], null, 2)}</pre>
+        <pre className="text-xs text-[#a3a3a3] bg-[#0D0D0D] p-4 rounded overflow-x-auto">{imfLoading ? "Chargement des données IMF..." : JSON.stringify(imfData?.[0], null, 2)}</pre>
+      </div>
 
       <div className="space-y-6">
         <h3 className="text-2xl font-semibold text-[#e5e5e5]">Fil d'actualité économique</h3>


### PR DESCRIPTION
## Summary
- add `useWorldBankIndicator` and `useIMFSeries` hooks for World Bank and IMF APIs
- demonstrate hook usage on Economic page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 829 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c3a9b27083308b6dec66465912cb