### PR TITLE
feat: add explorer tools for economic data and news

### DIFF
--- a/src/components/explorer/tools/ToolGDP.jsx
+++ b/src/components/explorer/tools/ToolGDP.jsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from 'react';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { TrendingUp } from 'lucide-react';
+
+export default function ToolGDP({ country }) {
+  const [gdp, setGdp] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!country) return;
+
+    const fetchGDP = async () => {
+      setLoading(true);
+      try {
+        const resCountry = await fetch(`https://restcountries.com/v3.1/name/${country}?fullText=true`);
+        const countryData = await resCountry.json();
+        const code = countryData[0]?.cca2?.toLowerCase();
+        const res = await fetch(`https://api.worldbank.org/v2/country/${code}/indicator/NY.GDP.MKTP.CD?format=json`);
+        const json = await res.json();
+        const validEntry = json[1]?.find(item => item.value !== null);
+        setGdp(validEntry ? validEntry.value : null);
+      } catch (e) {
+        setGdp(null);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchGDP();
+  }, [country]);
+
+  return (
+    <Card className="h-full bg-[#171717] border-[#2a2a2a]">
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-white text-sm font-mono">
+          <TrendingUp className="w-4 h-4" />
+          PIB (USD)
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <p className="text-[#a0a0a0] text-sm">Chargement...</p>
+        ) : gdp ? (
+          <p className="text-2xl font-bold text-white">{Number(gdp).toLocaleString('en-US')}</p>
+        ) : (
+          <p className="text-[#a0a0a0] text-sm">Données indisponibles</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/explorer/tools/ToolInflation.jsx
+++ b/src/components/explorer/tools/ToolInflation.jsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from 'react';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Percent } from 'lucide-react';
+
+export default function ToolInflation({ country }) {
+  const [inflation, setInflation] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!country) return;
+
+    const fetchInflation = async () => {
+      setLoading(true);
+      try {
+        const resCountry = await fetch(`https://restcountries.com/v3.1/name/${country}?fullText=true`);
+        const countryData = await resCountry.json();
+        const code = countryData[0]?.cca2?.toLowerCase();
+        const res = await fetch(`https://api.worldbank.org/v2/country/${code}/indicator/FP.CPI.TOTL.ZG?format=json`);
+        const json = await res.json();
+        const validEntry = json[1]?.find(item => item.value !== null);
+        setInflation(validEntry ? validEntry.value : null);
+      } catch (e) {
+        setInflation(null);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchInflation();
+  }, [country]);
+
+  return (
+    <Card className="h-full bg-[#171717] border-[#2a2a2a]">
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-white text-sm font-mono">
+          <Percent className="w-4 h-4" />
+          Inflation annuelle
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <p className="text-[#a0a0a0] text-sm">Chargement...</p>
+        ) : inflation !== null ? (
+          <p className="text-2xl font-bold text-white">{inflation.toFixed(2)}%</p>
+        ) : (
+          <p className="text-[#a0a0a0] text-sm">Données indisponibles</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/explorer/tools/ToolNews.jsx
+++ b/src/components/explorer/tools/ToolNews.jsx
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from 'react';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Newspaper } from 'lucide-react';
+
+export default function ToolNews({ country }) {
+  const [articles, setArticles] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!country) return;
+
+    const fetchNews = async () => {
+      setLoading(true);
+      try {
+        const resCountry = await fetch(`https://restcountries.com/v3.1/name/${country}?fullText=true`);
+        const countryData = await resCountry.json();
+        const code = countryData[0]?.cca2?.toLowerCase();
+        const res = await fetch(`https://gnews.io/api/v4/top-headlines?country=${code}&lang=fr&max=5&apikey=demo`);
+        const json = await res.json();
+        setArticles(json.articles || []);
+      } catch (e) {
+        setArticles([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchNews();
+  }, [country]);
+
+  return (
+    <Card className="h-full bg-[#171717] border-[#2a2a2a]">
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-white text-sm font-mono">
+          <Newspaper className="w-4 h-4" />
+          Actualités
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <p className="text-[#a0a0a0] text-sm">Chargement...</p>
+        ) : articles.length > 0 ? (
+          <ul className="space-y-2 text-sm list-disc list-inside">
+            {articles.map((article) => (
+              <li key={article.url} className="text-[#e5e5e5]">
+                <a href={article.url} target="_blank" rel="noopener noreferrer" className="hover:underline">
+                  {article.title}
+                </a>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-[#a0a0a0] text-sm">Aucune actualité trouvée</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/pages/Explorer.jsx
+++ b/src/pages/Explorer.jsx
@@ -2,6 +2,9 @@
 import React, { useState } from 'react';
 import InteractiveWorldMap from '../components/explorer/InteractiveWorldMap';
 import CountryDataPanel from '../components/explorer/CountryDataPanel';
+import ToolGDP from '../components/explorer/tools/ToolGDP';
+import ToolInflation from '../components/explorer/tools/ToolInflation';
+import ToolNews from '../components/explorer/tools/ToolNews';
 import { AnimatePresence } from 'framer-motion';
 
 // Données mock pour les détails des pays (inchangées)
@@ -95,25 +98,19 @@ export default function ExplorerPage() {
                     <InteractiveWorldMap onCountryClick={handleCountryClick} />
                 </div>
                 
-                {/* Zone étendue pour les outils futurs */}
+                {/* Outils opérationnels */}
                 <div className="flex-1 bg-[#2a2a2a] border border-[#3a3a3a] rounded-lg p-6">
-                    <div className="flex items-center justify-center h-full">
-                        <div className="text-center space-y-4">
-                            <h3 className="text-xl font-bold text-white font-mono tracking-wider">ZONE D'OUTILS OPÉRATIONNELS</h3>
-                            <p className="text-[#a0a0a0] font-mono">Espace réservé pour les outils d'analyse et contrôles tactiques.</p>
-                            <div className="grid grid-cols-3 gap-4 mt-8 max-w-md mx-auto">
-                                <div className="h-16 bg-[#3a3a3a] rounded border border-[#4a4a4a] flex items-center justify-center">
-                                    <span className="text-xs text-[#a0a0a0] font-mono">OUTIL 1</span>
-                                </div>
-                                <div className="h-16 bg-[#3a3a3a] rounded border border-[#4a4a4a] flex items-center justify-center">
-                                    <span className="text-xs text-[#a0a0a0] font-mono">OUTIL 2</span>
-                                </div>
-                                <div className="h-16 bg-[#3a3a3a] rounded border border-[#4a4a4a] flex items-center justify-center">
-                                    <span className="text-xs text-[#a0a0a0] font-mono">OUTIL 3</span>
-                                </div>
-                            </div>
+                    {selectedCountry ? (
+                        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 h-full">
+                            <ToolGDP country={selectedCountry.name} />
+                            <ToolInflation country={selectedCountry.name} />
+                            <ToolNews country={selectedCountry.name} />
                         </div>
-                    </div>
+                    ) : (
+                        <div className="flex items-center justify-center h-full">
+                            <p className="text-[#a0a0a0] font-mono">Sélectionnez un pays pour afficher les outils.</p>
+                        </div>
+                    )}
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
- add GDP, inflation, and news tool components for explorer
- display tools on explorer page when a country is selected

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: no-unused-vars and no-undef in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c3f0551c83309f8ab4bd02dd6b72