### PR TITLE
Add login page and redirect unauthenticated users

### DIFF
--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { User } from "@/api/entities";
+import { Button } from "@/components/ui/button";
+
+export default function Login() {
+  const handleLogin = async () => {
+    try {
+      await User.login();
+    } catch (error) {
+      console.error("Login error:", error);
+    }
+  };
+
+  const handleLogout = async () => {
+    try {
+      await User.logout();
+    } catch (error) {
+      console.error("Logout error:", error);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center h-full space-y-4">
+      <Button onClick={handleLogin} className="tactical-button">
+        SE CONNECTER
+      </Button>
+      <Button onClick={handleLogout} className="tactical-button">
+        SE DÉCONNECTER
+      </Button>
+    </div>
+  );
+}

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,3 +1,7 @@
+import { useEffect, useState } from "react";
+import { BrowserRouter as Router, Route, Routes, useLocation, Navigate } from 'react-router-dom';
+import { User } from "@/api/entities";
+
 import Layout from "./Layout.jsx";
 
 import Intelligence from "./Intelligence";
@@ -22,8 +26,7 @@ import Files from "./Files";
 
 import Terminal from "./Terminal";
 import Monitor from "./Monitor";
-
-import { BrowserRouter as Router, Route, Routes, useLocation } from 'react-router-dom';
+import Login from "./Login";
 
 const PAGES = {
     
@@ -69,37 +72,54 @@ function _getCurrentPage(url) {
 function PagesContent() {
     const location = useLocation();
     const currentPage = _getCurrentPage(location.pathname);
-    
+    const [isAuthenticated, setIsAuthenticated] = useState(null);
+
+    useEffect(() => {
+        async function checkAuth() {
+            try {
+                await User.me();
+                setIsAuthenticated(true);
+            } catch {
+                setIsAuthenticated(false);
+            }
+        }
+        checkAuth();
+    }, []);
+
+    if (isAuthenticated === false && location.pathname !== "/Intelligence" && location.pathname !== "/Login") {
+        return <Navigate to="/Intelligence" replace />;
+    }
+
     return (
         <Layout currentPageName={currentPage}>
-            <Routes>            
-                
-                    <Route path="/" element={<Intelligence />} />
-                
-                
+            <Routes>
+
+                <Route path="/" element={<Intelligence />} />
+
                 <Route path="/Intelligence" element={<Intelligence />} />
-                
+
                 <Route path="/Admin" element={<Admin />} />
-                
+
                 <Route path="/SocioDemographic" element={<SocioDemographic />} />
-                
+
                 <Route path="/Economic" element={<Economic />} />
-                
+
                 <Route path="/Financial" element={<Financial />} />
-                
+
                 <Route path="/Markets" element={<Markets />} />
-                
+
                 <Route path="/News" element={<News />} />
-                
+
                 <Route path="/Explorer" element={<Explorer />} />
-                
+
                 <Route path="/Tasks" element={<Tasks />} />
-                
+
                 <Route path="/Files" element={<Files />} />
-                
+
                 <Route path="/Terminal" element={<Terminal />} />
                 <Route path="/Monitor" element={<Monitor />} />
-                
+                <Route path="/Login" element={<Login />} />
+
             </Routes>
         </Layout>
     );


### PR DESCRIPTION
## Summary
- Redirect unauthenticated users to Intelligence and add /Login route
- Create simple Login page using User.login() and User.logout()

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: many existing lint errors)


------
https://chatgpt.com/codex/tasks/task_e_68a8c3fd51148330bce0cb07198b23e3