### PR TITLE
feat: restrict file and monitor actions by role

### DIFF
--- a/src/api/entities.js
+++ b/src/api/entities.js
@@ -1,6 +1,5 @@
 import { base44 } from './base44Client';
 
-
 export const Dataset = base44.entities.Dataset;
 
 export const Analysis = base44.entities.Analysis;
@@ -13,7 +12,11 @@ export const BrokerConnection = base44.entities.BrokerConnection;
 
 export const TradingBot = base44.entities.TradingBot;
 
-
-
 // auth sdk:
-export const User = base44.auth;
+export const User = {
+  ...base44.auth,
+  role: {
+    ADMIN: 'admin',
+    USER: 'user',
+  },
+};

--- a/src/components/files/DocumentList.jsx
+++ b/src/components/files/DocumentList.jsx
@@ -1,12 +1,11 @@
-
-import React from 'react';
+/* eslint-disable react/prop-types */
 import { Button } from "@/components/ui/button";
-import { FileText, BarChart3, Shield, AlertTriangle, Download, Star, StarOff, Trash2, FileCode } from 'lucide-react';
+import { FileText, Download, Star, StarOff, Trash2, FileCode } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import { fr } from 'date-fns/locale';
 
-export default function DocumentList({ documents, onSelect, selectedId, onToggleFavorite, onDelete, loading }) {
-    
+export default function DocumentList({ documents, onSelect, selectedId, onToggleFavorite, onDelete, loading, canDelete }) {
+
     const getTypeIcon = (type) => {
         switch (type) {
           case 'report': return FileText;
@@ -57,11 +56,11 @@ export default function DocumentList({ documents, onSelect, selectedId, onToggle
                 const isSelected = doc.id === selectedId;
 
                 return (
-                    <div 
+                    <div
                         key={doc.id}
                         className={`group relative p-3 rounded-md cursor-pointer transition-all duration-200 border ${
-                            isSelected 
-                                ? 'bg-[#ff6b35]/20 border-[#ff6b35]/50' 
+                            isSelected
+                                ? 'bg-[#ff6b35]/20 border-[#ff6b35]/50'
                                 : 'border-transparent hover:bg-[#3a3a3a]/50 hover:border-[#3a3a3a]'
                         }`}
                     >
@@ -75,8 +74,8 @@ export default function DocumentList({ documents, onSelect, selectedId, onToggle
                                 </div>
                                 <div className="space-y-1">
                                     <p className="text-xs text-[#a0a0a0] font-mono">
-                                        {doc.generation_date 
-                                            ? formatDistanceToNow(new Date(doc.generation_date), { addSuffix: true, locale: fr }) 
+                                        {doc.generation_date
+                                            ? formatDistanceToNow(new Date(doc.generation_date), { addSuffix: true, locale: fr })
                                             : 'Date inconnue'
                                         }
                                     </p>
@@ -107,7 +106,7 @@ export default function DocumentList({ documents, onSelect, selectedId, onToggle
                             >
                                 {doc.is_favorite ? <Star className="w-3 h-3 fill-current" /> : <StarOff className="w-3 h-3" />}
                             </Button>
-                            
+
                             {doc.file_url && (
                                 <Button
                                     variant="ghost"
@@ -121,20 +120,22 @@ export default function DocumentList({ documents, onSelect, selectedId, onToggle
                                     <Download className="w-3 h-3" />
                                 </Button>
                             )}
-                            
-                            <Button
-                                variant="ghost"
-                                size="icon"
-                                onClick={(e) => {
-                                    e.stopPropagation();
-                                    if (confirm('Êtes-vous sûr de vouloir supprimer ce document ?')) {
-                                        onDelete(doc.id);
-                                    }
-                                }}
-                                className="h-6 w-6 text-[#a0a0a0] hover:text-red-400"
-                            >
-                                <Trash2 className="w-3 h-3" />
-                            </Button>
+
+                            {canDelete && onDelete && (
+                                <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        if (confirm('Êtes-vous sûr de vouloir supprimer ce document ?')) {
+                                            onDelete(doc.id);
+                                        }
+                                    }}
+                                    className="h-6 w-6 text-[#a0a0a0] hover:text-red-400"
+                                >
+                                    <Trash2 className="w-3 h-3" />
+                                </Button>
+                            )}
                         </div>
                     </div>
                 );

--- a/src/components/files/DocumentViewer.jsx
+++ b/src/components/files/DocumentViewer.jsx
@@ -1,10 +1,11 @@
-import React, { useState, useEffect } from 'react';
+/* eslint-disable react/prop-types */
+import { useState, useEffect } from 'react';
 import ReactQuill from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle, CardFooter } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Edit, Save, Trash2, X, FileCode, FileText, Image as ImageIcon, Download } from 'lucide-react';
+import { Edit, Save, Trash2, X, Download } from 'lucide-react';
 import { format } from 'date-fns';
 import { fr } from 'date-fns/locale';
 
@@ -14,7 +15,7 @@ const QuillModules = {
     ['bold', 'italic', 'underline','strike', 'blockquote'],
     [{'list': 'ordered'}, {'list': 'bullet'}, {'indent': '-1'}, {'indent': '+1'}],
     ['link'],
-    ['clean']
+    ['clean'],
   ],
 };
 
@@ -25,7 +26,7 @@ const getMimeType = (url) => {
     return 'application/octet-stream';
 };
 
-export default function DocumentViewer({ document, onUpdate, onDelete }) {
+export default function DocumentViewer({ document, onUpdate, onDelete, canEdit, canDelete }) {
     const [isEditing, setIsEditing] = useState(false);
     const [title, setTitle] = useState(document.title);
     const [content, setContent] = useState(document.content || "");
@@ -35,7 +36,7 @@ export default function DocumentViewer({ document, onUpdate, onDelete }) {
         setTitle(document.title);
         setContent(document.content || "");
         setLanguage(document.language || "");
-        setIsEditing(false); 
+        setIsEditing(false);
     }, [document]);
 
     const handleSave = () => {
@@ -46,7 +47,7 @@ export default function DocumentViewer({ document, onUpdate, onDelete }) {
         onUpdate(document.id, updatedData);
         setIsEditing(false);
     };
-    
+
     const renderFilePreview = () => {
         const mimeType = getMimeType(document.file_url);
         if (mimeType.startsWith('image/')) {
@@ -69,7 +70,7 @@ export default function DocumentViewer({ document, onUpdate, onDelete }) {
     const renderEditor = () => {
         if (document.type === 'code') {
             return (
-                <textarea 
+                <textarea
                     value={content}
                     onChange={(e) => setContent(e.target.value)}
                     className="w-full h-full p-4 bg-[#1a1a1a] border border-[#3a3a3a] rounded-md text-white font-mono text-sm resize-none"
@@ -78,9 +79,9 @@ export default function DocumentViewer({ document, onUpdate, onDelete }) {
             );
         }
         return (
-            <ReactQuill 
-                theme="snow" 
-                value={content} 
+            <ReactQuill
+                theme="snow"
+                value={content}
                 onChange={setContent}
                 modules={QuillModules}
                 className="bg-white text-black h-full"
@@ -93,7 +94,7 @@ export default function DocumentViewer({ document, onUpdate, onDelete }) {
             <CardHeader className="flex-row items-center justify-between">
                 <div>
                     {isEditing ? (
-                        <input 
+                        <input
                           value={title}
                           onChange={(e) => setTitle(e.target.value)}
                           className="text-xl font-bold text-white font-mono bg-transparent border-b border-dotted border-[#3a3a3a] focus:outline-none focus:border-solid"
@@ -106,19 +107,23 @@ export default function DocumentViewer({ document, onUpdate, onDelete }) {
                     </p>
                 </div>
                 <div className="flex items-center gap-2">
-                    {isEditing ? (
-                        <>
-                            <Button size="sm" onClick={handleSave} className="tactical-button"><Save className="w-4 h-4 mr-2" /> Enregistrer</Button>
-                            <Button size="sm" variant="ghost" onClick={() => setIsEditing(false)}><X className="w-4 h-4" /></Button>
-                        </>
-                    ) : (
-                        <Button size="sm" variant="outline" onClick={() => setIsEditing(true)} className="border-[#3a3a3a] text-[#a0a0a0] hover:bg-[#3a3a3a] hover:text-white">
-                            <Edit className="w-4 h-4 mr-2" /> Éditer
+                    {canEdit && (
+                        isEditing ? (
+                            <>
+                                <Button size="sm" onClick={handleSave} className="tactical-button"><Save className="w-4 h-4 mr-2" /> Enregistrer</Button>
+                                <Button size="sm" variant="ghost" onClick={() => setIsEditing(false)}><X className="w-4 h-4" /></Button>
+                            </>
+                        ) : (
+                            <Button size="sm" variant="outline" onClick={() => setIsEditing(true)} className="border-[#3a3a3a] text-[#a0a0a0] hover:bg-[#3a3a3a] hover:text-white">
+                                <Edit className="w-4 h-4 mr-2" /> Éditer
+                            </Button>
+                        )
+                    )}
+                    {canDelete && (
+                        <Button size="icon" variant="destructive" onClick={() => onDelete(document.id)}>
+                            <Trash2 className="w-4 h-4" />
                         </Button>
                     )}
-                    <Button size="icon" variant="destructive" onClick={() => onDelete(document.id)}>
-                        <Trash2 className="w-4 h-4" />
-                    </Button>
                 </div>
             </CardHeader>
             <CardContent className="flex-1 overflow-y-auto p-6 flex flex-col">

--- a/src/components/files/FileCreationView.jsx
+++ b/src/components/files/FileCreationView.jsx
@@ -1,31 +1,29 @@
-
-import React from 'react';
+/* eslint-disable react/prop-types */
 import { Button } from '@/components/ui/button';
-import { Card, CardContent } from '@/components/ui/card';
-import { FileText, FileCode, Upload, Loader2, Slash } from 'lucide-react';
+import { FileText, FileCode, Upload, Loader2 } from 'lucide-react';
 import StrategicGlobe3D from '../common/StrategicGlobe3D';
 import DocumentViewer from './DocumentViewer';
 
 const documentTypes = [
-    { 
-        type: 'report', 
-        icon: FileText, 
-        label: 'Document', 
+    {
+        type: 'report',
+        icon: FileText,
+        label: 'Document',
         color: 'text-blue-400 border-blue-500/30 hover:bg-blue-500/10'
     },
-    { 
-        type: 'code', 
-        icon: FileCode, 
-        label: 'Code', 
+    {
+        type: 'code',
+        icon: FileCode,
+        label: 'Code',
         color: 'text-green-400 border-green-500/30 hover:bg-green-500/10'
     }
 ];
 
-export default function FileCreationView({ onUploadClick, onCreateDocument, uploading, selectedDocument, onUpdate, onDelete }) {
-    
+export default function FileCreationView({ onUploadClick, onCreateDocument, uploading, selectedDocument, onUpdate, onDelete, canEdit, canDelete }) {
+
     // Si un document est sélectionné, afficher le visualiseur
     if (selectedDocument) {
-        return <DocumentViewer document={selectedDocument} onUpdate={onUpdate} onDelete={onDelete} />;
+        return <DocumentViewer document={selectedDocument} onUpdate={onUpdate} onDelete={onDelete} canEdit={canEdit} canDelete={canDelete} />;
     }
 
     return (
@@ -34,7 +32,7 @@ export default function FileCreationView({ onUploadClick, onCreateDocument, uplo
             <div className="h-80 w-full max-w-lg mx-auto mt-8 mb-12">
                 <StrategicGlobe3D height={320} />
             </div>
-            
+
             {/* Zone de création centrée */}
             <div className="flex-1 flex flex-col items-center justify-start space-y-8 max-w-sm mx-auto">
                 <div className="flex items-center justify-center gap-3">
@@ -42,7 +40,7 @@ export default function FileCreationView({ onUploadClick, onCreateDocument, uplo
                         Créer ou télécharger
                     </h2>
                 </div>
-                
+
                 <div className="grid grid-cols-2 gap-4 w-full">
                     {documentTypes.map(({ type, icon: Icon, label, color }) => (
                         <Button
@@ -57,8 +55,8 @@ export default function FileCreationView({ onUploadClick, onCreateDocument, uplo
                     ))}
                 </div>
 
-                <Button 
-                    variant="outline" 
+                <Button
+                    variant="outline"
                     size="lg"
                     onClick={onUploadClick}
                     disabled={uploading}

--- a/src/pages/Files.jsx
+++ b/src/pages/Files.jsx
@@ -1,5 +1,5 @@
 
-import React, { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Document } from "@/api/entities"; // Changed from base44
 import { User } from "@/api/entities";
 import { Button } from "@/components/ui/button";
@@ -16,7 +16,7 @@ import {
 } from "lucide-react";
 import DocumentList from "../components/files/DocumentList";
 import FileCreationView from "../components/files/FileCreationView";
-import { UploadFile, ExtractDataFromUploadedFile } from "@/api/integrations";
+import { UploadFile } from "@/api/integrations";
 
 export default function FilesPage() {
   const [documents, setDocuments] = useState([]);
@@ -32,6 +32,7 @@ export default function FilesPage() {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [authChecked, setAuthChecked] = useState(false);
   const [showFilters, setShowFilters] = useState(false);
+  const [userRole, setUserRole] = useState(null);
   const fileInputRef = useRef(null);
 
   useEffect(() => {
@@ -44,10 +45,11 @@ export default function FilesPage() {
 
   const checkAuthAndLoadDocuments = async () => {
     try {
-      await User.me();
+      const me = await User.me();
       setIsAuthenticated(true);
+      setUserRole(me.role);
       await loadDocuments();
-    } catch (error) {
+    } catch {
       setIsAuthenticated(false);
     } finally {
       setAuthChecked(true);
@@ -264,6 +266,7 @@ export default function FilesPage() {
     );
   }
 
+  const isAdmin = userRole === User.role.ADMIN;
   const activeFiltersCount =
     (selectedCategory !== "all" ? 1 : 0) +
     (selectedType !== "all" ? 1 : 0) +
@@ -412,6 +415,7 @@ export default function FilesPage() {
             onToggleFavorite={toggleFavorite}
             onDelete={deleteDocument}
             loading={loading}
+            canDelete={isAdmin}
           />
         </div>
       </div>
@@ -425,6 +429,8 @@ export default function FilesPage() {
           selectedDocument={selectedDocument}
           onUpdate={updateDocument}
           onDelete={deleteDocument}
+          canEdit={isAdmin}
+          canDelete={isAdmin}
         />
         <input
           type="file"

--- a/src/pages/Monitor.jsx
+++ b/src/pages/Monitor.jsx
@@ -1,7 +1,17 @@
-import React from "react";
+import { useEffect, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { User } from "@/api/entities";
 
 export default function MonitorPage() {
+  const [role, setRole] = useState(null);
+
+  useEffect(() => {
+    User.me().then(u => setRole(u.role)).catch(() => {});
+  }, []);
+
+  const isAdmin = role === User.role.ADMIN;
+
   return (
     <div className="h-full flex items-center justify-center">
       <Card className="p-8 text-center">
@@ -10,6 +20,12 @@ export default function MonitorPage() {
           <p className="text-[#a0a0a0] font-mono">
             Créateur de tableaux de bord en cours de développement.
           </p>
+          {isAdmin && (
+            <div className="flex justify-center gap-2 pt-4">
+              <Button size="sm">Éditer</Button>
+              <Button size="sm" variant="destructive">Supprimer</Button>
+            </div>
+          )}
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- extend entities to expose `User.role`
- hide file edit/delete actions for non-admin users
- conditionally show monitor edit/delete buttons based on role

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: many errors)*
- `npx eslint src/api/entities.js src/components/files/DocumentList.jsx src/components/files/DocumentViewer.jsx src/components/files/FileCreationView.jsx src/pages/Files.jsx src/pages/Monitor.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68a8c3fe12e48330a1868c2a1fc07753