### PR TITLE
feat(task): allow scheduling

### DIFF
--- a/src/api/entities.js
+++ b/src/api/entities.js
@@ -7,6 +7,31 @@ export const Analysis = base44.entities.Analysis;
 
 export const Task = base44.entities.Task;
 
+if (!Task.schedule) {
+  Task.schedule = async (id, data) => {
+    const { serverUrl, appId } = base44.getConfig();
+    const token = typeof window !== 'undefined' ? localStorage.getItem('base44_access_token') : null;
+
+    const response = await fetch(
+      `${serverUrl}/api/apps/${appId}/entities/Task/${id}/schedule`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {})
+        },
+        body: JSON.stringify(data)
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`Failed to schedule task: ${response.statusText}`);
+    }
+
+    return response.json();
+  };
+}
+
 export const Document = base44.entities.Document;
 
 export const BrokerConnection = base44.entities.BrokerConnection;

--- a/src/components/tasks/TaskForm.jsx
+++ b/src/components/tasks/TaskForm.jsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import { useState } from "react";
+import PropTypes from "prop-types";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -12,7 +13,10 @@ export default function TaskForm({ onSubmit, onCancel, selectedTemplate }) {
     description: selectedTemplate?.description || "",
     type: selectedTemplate?.type || "",
     category: selectedTemplate?.category || "",
+    outputDatasetId: selectedTemplate?.outputDatasetId || "",
     frequency: "daily",
+    // Heure d'exécution au format HH:MM
+    trigger: "09:00",
     parameters: {
       email_notifications: true
     }
@@ -107,10 +111,23 @@ export default function TaskForm({ onSubmit, onCancel, selectedTemplate }) {
               </div>
             </div>
 
+            {/* Output Dataset ID */}
+            <div>
+              <label className="block text-sm font-bold text-[#a0a0a0] mb-2 font-mono uppercase tracking-wider">
+                ID du dataset de sortie
+              </label>
+              <Input
+                placeholder="Dataset ID"
+                value={formData.outputDatasetId}
+                onChange={(e) => setFormData({ ...formData, outputDatasetId: e.target.value })}
+                className="bg-[#1a1a1a] border-[#3a3a3a] text-white font-mono"
+              />
+            </div>
+
             {/* Fréquence */}
             <div>
               <label className="block text-sm font-bold text-[#a0a0a0] mb-2 font-mono uppercase tracking-wider">
-                Fréquence d'exécution
+                Fréquence d&apos;exécution
               </label>
               <Select value={formData.frequency} onValueChange={(value) => setFormData({...formData, frequency: value})}>
                 <SelectTrigger className="bg-[#1a1a1a] border-[#3a3a3a] text-white font-mono">
@@ -123,6 +140,20 @@ export default function TaskForm({ onSubmit, onCancel, selectedTemplate }) {
                   <SelectItem value="quarterly" className="text-white font-mono">Trimestriel</SelectItem>
                 </SelectContent>
               </Select>
+            </div>
+
+            {/* Heure d&apos;exécution */}
+            <div>
+              <label className="block text-sm font-bold text-[#a0a0a0] mb-2 font-mono uppercase tracking-wider">
+                Heure d&apos;exécution
+              </label>
+              <Input
+                type="time"
+                value={formData.trigger}
+                onChange={(e) => setFormData({ ...formData, trigger: e.target.value })}
+                className="bg-[#1a1a1a] border-[#3a3a3a] text-white font-mono"
+                required
+              />
             </div>
 
             {/* Actions */}
@@ -140,3 +171,15 @@ export default function TaskForm({ onSubmit, onCancel, selectedTemplate }) {
     </div>
   );
 }
+
+TaskForm.propTypes = {
+  onSubmit: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  selectedTemplate: PropTypes.shape({
+    title: PropTypes.string,
+    description: PropTypes.string,
+    type: PropTypes.string,
+    category: PropTypes.string,
+    outputDatasetId: PropTypes.string
+  })
+};

--- a/src/pages/Tasks.jsx
+++ b/src/pages/Tasks.jsx
@@ -1,20 +1,10 @@
 
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { Task } from "@/api/entities"; // Changed from base44 client to direct Task entity import
 import { User } from "@/api/entities";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { 
-  Plus, 
-  Search,
-  Settings,
-  LogIn,
-  Clock,
-  Play,
-  Pause,
-  MoreVertical
-} from "lucide-react";
+import { Plus, Search, Settings, LogIn } from "lucide-react";
 import TaskForm from "../components/tasks/TaskForm";
 import TaskCard from "../components/tasks/TaskCard";
 import TaskTemplates from "../components/tasks/TaskTemplates";
@@ -31,6 +21,7 @@ export default function TasksPage() {
 
   useEffect(() => {
     checkAuthAndLoadTasks();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const checkAuthAndLoadTasks = async () => {
@@ -69,10 +60,23 @@ export default function TasksPage() {
 
   const handleCreateTask = async (taskData) => {
     try {
-      await Task.create({ // Changed from base44.entities.Task.create()
-        ...taskData,
-        next_execution: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+      const { outputDatasetId, frequency, trigger, ...payload } = taskData;
+      const [hours, minutes] = trigger.split(":").map(Number);
+      const nextExecution = new Date();
+      nextExecution.setHours(hours, minutes, 0, 0);
+      if (nextExecution <= new Date()) {
+        nextExecution.setDate(nextExecution.getDate() + 1);
+      }
+      const newTask = await Task.create({
+        ...payload,
+        output_dataset_id: outputDatasetId,
+        next_execution: nextExecution.toISOString(),
       });
+
+      if (newTask?.id) {
+        await Task.schedule(newTask.id, { frequency, trigger });
+      }
+
       setShowForm(false);
       setSelectedTemplate(null);
       await loadTasks();
@@ -162,7 +166,7 @@ export default function TasksPage() {
               Commencez par ajouter une tâche
             </h3>
             <p className="text-[#a0a0a0] font-mono text-base max-w-md">
-              Planifier une tâche pour automatiser des actions et recevoir des rapports lorsqu'elles sont terminées.
+              Planifier une tâche pour automatiser des actions et recevoir des rapports lorsqu&apos;elles sont terminées.
             </p>
           </div>
           


### PR DESCRIPTION
## Summary
- add custom `Task.schedule` endpoint
- expose trigger field and scheduling in task form
- schedule tasks when created
- address lint issues and add prop types
- compute next execution time from trigger
- retain output dataset ID field when scheduling tasks

## Testing
- `npm run lint` *(fails: 811 problems)*
- `npx eslint src/api/entities.js src/components/tasks/TaskForm.jsx src/pages/Tasks.jsx`
- `npm run build`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8c10f1ed08330b8dac4c9680aa311