### PR TITLE
chore: bump app version to 0.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "base44-app",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "base44-app",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "dependencies": {
         "@base44/sdk": "^0.1.2",
         "@hookform/resolvers": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base44-app",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -35,7 +35,7 @@ export default function Layout({ children }) {
     return (
         <div className="flex h-screen w-full bg-[#1a1a1a] relative overflow-hidden">
             <AnimatedBackground />
-            <style jsx global>{`
+            <style>{`
                 @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&display=swap');
                 
                 :root {


### PR DESCRIPTION
## Summary
- bump package version to 0.0.1 to match layout display
- remove unused styled-jsx attributes to eliminate test warnings

## Testing
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8f6da75108330ac40890879b56f2a