### PR TITLE
feat: add advanced analytics section to terminal

### DIFF
--- a/src/api/historicalData.js
+++ b/src/api/historicalData.js
@@ -1,0 +1,18 @@
+export async function fetchHistoricalData(symbol, range = '1y', interval = '1d') {
+  // Utilise l'endpoint historique de Yahoo Finance, identique à celui employé par yfinance
+  const url = `https://query1.finance.yahoo.com/v8/finance/chart/${symbol}?range=${range}&interval=${interval}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error('Failed to fetch historical data');
+  }
+  const json = await res.json();
+  const result = json.chart?.result?.[0];
+  const timestamps = result?.timestamp || [];
+  const closes = result?.indicators?.quote?.[0]?.close || [];
+  return timestamps.map((t, i) => ({
+    date: new Date(t * 1000),
+    close: closes[i],
+  }));
+}
+
+export default fetchHistoricalData;

--- a/src/components/terminal/AdvancedAnalytics.jsx
+++ b/src/components/terminal/AdvancedAnalytics.jsx
@@ -1,0 +1,127 @@
+import React, { useState, useEffect } from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+  ResponsiveContainer,
+} from 'recharts';
+import fetchHistoricalData from '../../api/historicalData';
+
+const computeSMA = (data, period) => {
+  const sma = [];
+  for (let i = 0; i < data.length; i++) {
+    if (i < period - 1) {
+      sma.push(null);
+      continue;
+    }
+    const slice = data.slice(i - period + 1, i + 1);
+    const sum = slice.reduce((acc, val) => acc + val, 0);
+    sma.push(sum / period);
+  }
+  return sma;
+};
+
+const linearRegressionPredict = (data) => {
+  const n = data.length;
+  if (n < 2) return null;
+  let sumX = 0,
+    sumY = 0,
+    sumXY = 0,
+    sumXX = 0;
+  for (let i = 0; i < n; i++) {
+    const x = i;
+    const y = data[i].close;
+    sumX += x;
+    sumY += y;
+    sumXY += x * y;
+    sumXX += x * x;
+  }
+  const slope = (n * sumXY - sumX * sumY) / (n * sumXX - sumX * sumX);
+  const intercept = (sumY - slope * sumX) / n;
+  const nextX = n;
+  return intercept + slope * nextX;
+};
+
+const AdvancedAnalytics = () => {
+  const [symbol, setSymbol] = useState('AAPL');
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [prediction, setPrediction] = useState(null);
+
+  const loadData = async (s) => {
+    setLoading(true);
+    try {
+      const hist = await fetchHistoricalData(s);
+      const closes = hist.map((d) => d.close);
+      const sma20 = computeSMA(closes, 20);
+      const sma50 = computeSMA(closes, 50);
+      const pred = linearRegressionPredict(hist.slice(-60));
+      setPrediction(pred);
+      const merged = hist.map((d, i) => ({
+        date: d.date.toISOString().slice(0, 10),
+        close: d.close,
+        sma20: sma20[i],
+        sma50: sma50[i],
+      }));
+      setData(merged);
+    } catch (err) {
+      console.error('Failed to load historical data', err);
+      setData([]);
+      setPrediction(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadData(symbol);
+  }, [symbol]);
+
+  return (
+    <div className="space-y-4 p-4">
+      <div className="flex items-center space-x-2">
+        <input
+          type="text"
+          value={symbol}
+          onChange={(e) => setSymbol(e.target.value.toUpperCase())}
+          className="px-2 py-1 border rounded w-32"
+        />
+        <button
+          onClick={() => loadData(symbol)}
+          className="px-4 py-1 bg-primary text-primary-foreground rounded"
+        >
+          Charger
+        </button>
+      </div>
+      {loading && <p>Loading...</p>}
+      {!loading && data.length > 0 && (
+        <>
+          <div className="h-64">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={data} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#2a2a2a" />
+                <XAxis dataKey="date" hide />
+                <YAxis domain={["auto", "auto"]} />
+                <Tooltip />
+                <Line type="monotone" dataKey="close" stroke="#8884d8" dot={false} />
+                <Line type="monotone" dataKey="sma20" stroke="#82ca9d" dot={false} />
+                <Line type="monotone" dataKey="sma50" stroke="#ffc658" dot={false} />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+          {prediction && (
+            <p className="text-sm text-[#a0a0a0] font-mono">
+              Prévision prochaine clôture: {prediction.toFixed(2)}
+            </p>
+          )}
+        </>
+      )}
+      {!loading && data.length === 0 && <p>Aucune donnée</p>}
+    </div>
+  );
+};
+
+export default AdvancedAnalytics;

--- a/src/pages/Terminal.jsx
+++ b/src/pages/Terminal.jsx
@@ -1,5 +1,6 @@
-import { CheckCircle } from "lucide-react";
+import { CheckCircle, LineChart } from "lucide-react";
 import GlobalIndices from "../components/markets/GlobalIndices";
+import AdvancedAnalytics from "../components/terminal/AdvancedAnalytics";
 
 /**
  * TerminalPage affiche les principaux indices boursiers mondiaux sans exiger
@@ -19,17 +20,31 @@ export default function TerminalPage() {
         </div>
       </div>
 
-      {/* Tableau des indices */}
-      <div className="flex-1 overflow-hidden">
-        <div className="bg-[#1a1a1a] border border-[#3a3a3a] rounded-md overflow-hidden h-[calc(100vh-200px)]">
+      {/* Sections */}
+      <div className="flex-1 overflow-y-auto space-y-6">
+        {/* Tableau des indices */}
+        <div className="bg-[#1a1a1a] border border-[#3a3a3a] rounded-md overflow-hidden">
           <div className="flex items-center gap-4 text-sm font-mono p-3 border-b border-[#3a3a3a]">
             <div className="flex items-center gap-2 text-white">
               <CheckCircle className="w-4 h-4 text-[#ff6b35]" />
               <span>Indices Globaux</span>
             </div>
           </div>
-          <div className="overflow-y-auto h-full">
+          <div className="overflow-y-auto h-96">
             <GlobalIndices />
+          </div>
+        </div>
+
+        {/* Analytics avancés */}
+        <div className="bg-[#1a1a1a] border border-[#3a3a3a] rounded-md overflow-hidden">
+          <div className="flex items-center gap-4 text-sm font-mono p-3 border-b border-[#3a3a3a]">
+            <div className="flex items-center gap-2 text-white">
+              <LineChart className="w-4 h-4 text-[#ff6b35]" />
+              <span>Analytics Avancés</span>
+            </div>
+          </div>
+          <div className="overflow-y-auto h-96">
+            <AdvancedAnalytics />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add API helper to fetch historical quotes via Yahoo Finance (yfinance endpoint)
- build AdvancedAnalytics component with moving averages and linear regression chart
- integrate analytics section on Terminal page

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a943dc771883308722d6ef1f2ec062