### PR TITLE
Add exchange page integrating trading components

### DIFF
--- a/src/pages/Exchange.jsx
+++ b/src/pages/Exchange.jsx
@@ -1,0 +1,46 @@
+import React, { useState, useEffect } from "react";
+import TradingDashboard from "../components/exchange/TradingDashboard";
+import BrokerConnections from "../components/exchange/BrokerConnections";
+import BotManager from "../components/exchange/BotManager";
+import Portfolio from "../components/exchange/Portfolio";
+import OrderBook from "../components/exchange/OrderBook";
+import { BrokerConnection, TradingBot } from "@/api/entities";
+
+export default function ExchangePage() {
+  const [connections, setConnections] = useState([]);
+  const [bots, setBots] = useState([]);
+
+  useEffect(() => {
+    loadConnections();
+    loadBots();
+  }, []);
+
+  const loadConnections = async () => {
+    try {
+      const data = await BrokerConnection.list();
+      setConnections(data);
+    } catch (error) {
+      console.error("Error loading connections:", error);
+    }
+  };
+
+  const loadBots = async () => {
+    try {
+      const data = await TradingBot.list();
+      setBots(data);
+    } catch (error) {
+      console.error("Error loading bots:", error);
+    }
+  };
+
+  return (
+    <div className="space-y-8">
+      <TradingDashboard connections={connections} bots={bots} />
+      <BrokerConnections connections={connections} onUpdate={loadConnections} />
+      <BotManager bots={bots} connections={connections} onUpdate={loadBots} />
+      <Portfolio connections={connections} />
+      <OrderBook connections={connections} />
+    </div>
+  );
+}
+

--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -11,6 +11,7 @@ import {
   Settings,
   TrendingUp,
   BarChart3,
+  Bot,
 } from "lucide-react";
 import AnimatedBackground from "../components/common/AnimatedBackground";
 import GlobalSearch from "../components/common/GlobalSearch";
@@ -20,6 +21,7 @@ const mainNavItems = [
     { title: 'TÂCHES', href: createPageUrl('Tasks'), icon: Settings },
     { title: 'FICHIERS', href: createPageUrl('Files'), icon: LayoutGrid },
     { title: 'TERMINAL', href: createPageUrl('Terminal'), icon: TrendingUp },
+    { title: 'EXCHANGE', href: createPageUrl('Exchange'), icon: Bot },
     { title: 'MONITOR', href: createPageUrl('Monitor'), icon: BarChart3 },
     { title: 'DASHBOARD', href: createPageUrl('Dashboard'), icon: LayoutDashboard },
   ];

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -15,19 +15,20 @@ const Files = lazy(() => import('./Files'));
 const Exploration = lazy(() => import('./Exploration'));
 const Monitor = lazy(() => import('./Monitor'));
 const Dashboard = lazy(() => import('./Dashboard'));
+const Exchange = lazy(() => import('./Exchange'));
 
 const PAGES = {
-    
+
     Intelligence: Intelligence,
-    
+
     Admin: Admin,
-    
+
     SocioDemographic: SocioDemographic,
-    
+
     Economic: Economic,
-    
+
     Financial: Financial,
-    
+
     Markets: Markets,
 
     News: News,
@@ -37,6 +38,8 @@ const PAGES = {
     Tasks: Tasks,
 
     Files: Files,
+
+    Exchange: Exchange,
 
     Monitor: Monitor,
     Dashboard: Dashboard,
@@ -76,6 +79,7 @@ function PagesContent() {
                     <Route path="/Exploration" element={<Exploration />} />
                     <Route path="/Tasks" element={<Tasks />} />
                     <Route path="/Files" element={<Files />} />
+                    <Route path="/Exchange" element={<Exchange />} />
                     <Route path="/Monitor" element={<Monitor />} />
                     <Route path="/Dashboard" element={<Dashboard />} />
                 </Routes>


### PR DESCRIPTION
## Summary
- Create dedicated Exchange page wiring dashboard, broker connections, bots, portfolio and order book components
- Expose Exchange route and navigation entry

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a94b4d5ea88330bfae283a195d062f